### PR TITLE
Release polish and v0.4.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ When implementing a new decoder factory: always pre-add `pos_encodings` from the
 **Algorithm** defines the learning paradigm (how to train/predict):
 - Behavioral Cloning: direct supervision
 - Diffusion: iterative denoising
-- Flow Matching: continuous normalizing flows
+- Flow Matching: velocity-field regression along noise-to-action paths
 
 **Architecture** defines the neural network structure:
 - Transformer, MLP, UNet, DETR, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-05
+
+### Fixed
+- The bundled Roboto Serif font ships with its SIL Open Font License text, as
+  the OFL requires for redistribution.
+- The PyPI project page renders the logo and reflects the reworked README.
+
+### Added
+- `CITATION.cff` and a `CONTRIBUTING.md` contributor guide.
+
+### Changed
+- README rewritten as a showcase; deep-dive material moved into the docs.
+- Flow matching is described as simulation-free velocity-field regression and
+  cites Lipman et al. (arXiv:2210.02747) instead of the Rectified Flow paper.
+- Documentation refresh: published dataset links, quantization/compression
+  background sections, ExecuTorch source-build instructions in the
+  installation guide, and an explainability card on the docs landing page.
+
 ## [0.4.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1] - 2026-07-05
 
 ### Fixed
-- The bundled Roboto Serif font ships with its SIL Open Font License text, as
-  the OFL requires for redistribution.
-- The PyPI project page renders the logo and reflects the reworked README.
+- Ship the SIL OFL license text with the bundled Roboto Serif font.
+- The PyPI project page renders the logo correctly.
 
 ### Added
 - `CITATION.cff` and a `CONTRIBUTING.md` contributor guide.
 
 ### Changed
-- README rewritten as a showcase; deep-dive material moved into the docs.
-- Flow matching is described as simulation-free velocity-field regression and
-  cites Lipman et al. (arXiv:2210.02747) instead of the Rectified Flow paper.
-- Documentation refresh: published dataset links, quantization/compression
-  background sections, ExecuTorch source-build instructions in the
-  installation guide, and an explainability card on the docs landing page.
+- README rewritten and documentation refreshed for the public release.
 
 ## [0.4.0] - 2026-07-05
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,5 +12,5 @@ authors:
 repository-code: "https://github.com/Lorenzo-Mazza/VersatIL"
 url: "https://lorenzo-mazza.github.io/VersatIL"
 license: MIT
-version: 0.4.0
+version: 0.4.1
 date-released: 2026-07-05

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: "If you use VersatIL in your research, please cite it as below."
+type: software
+title: "VersatIL: A Modular Imitation Learning Framework for Robot Policies"
+authors:
+  - family-names: Mazza
+    given-names: Lorenzo
+  - family-names: Rodriguez
+    given-names: Ariel
+  - family-names: Speidel
+    given-names: Stefanie
+repository-code: "https://github.com/Lorenzo-Mazza/VersatIL"
+url: "https://lorenzo-mazza.github.io/VersatIL"
+license: MIT
+version: 0.4.0
+date-released: 2026-07-05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to VersatIL
+
+Thanks for your interest in contributing! Bug reports, fixes, new components,
+and documentation improvements are all welcome.
+
+## Development Setup
+
+Install VersatIL from source following the
+[installation guide](https://lorenzo-mazza.github.io/VersatIL/getting-started/installation/)
+(Option B or C). `uv sync` installs the `dev` dependency group (pytest,
+pytest-cov, ruff, pre-commit) by default, so the environment is ready for
+development out of the box.
+
+Then install the pre-commit hooks, which run Ruff formatting and linting on
+every `git commit`:
+
+```bash
+pre-commit install
+```
+
+## Running Tests
+
+```bash
+# Run the default local suite: excludes slow, integration, GPU-only, and ExecuTorch-dependent tests
+pytest
+
+# Run all tests including integration tests
+pytest -m ""
+
+# Run specific test file
+pytest tests/models/test_policy.py
+
+# Run tests by marker
+pytest -m "unit"                                      # Fast tests with mocked dependencies
+pytest -m "integration"                               # Real component integration tests
+pytest -m "requires_gpu"                              # GPU-required tests
+pytest -m "not slow and not integration and not requires_gpu"  # Explicit default selection
+```
+
+Before writing or modifying tests, read [tests/AGENTS.md](tests/AGENTS.md) for
+the mandatory testing guidelines (fixtures, factories, assertion conventions).
+
+## Code Style
+
+- **Docstrings**: Google-style, concise (avoid LLM patterns like numbered lists or excessive words)
+- **Type hints**: Required for all function signatures
+- **Formatter/Linter**: [Ruff](https://docs.astral.sh/ruff/) (line length 88, lint target pinned to `py313` so annotation imports stay at runtime for OmegaConf)
+- **No inline imports**: All imports at module top
+- **Minimal comments**: Only for tensor shapes or non-obvious logic
+- **Variables**: Use English words, avoid abbreviations
+- **Function calls**: Use kwargs
+- **Error handling**: Use `raise`, avoid assertions and try/catch blocks
+- **Strings**: Use double quotes (`"foo"` not `'foo'`)
+- **Constants**: Avoid hardcoded strings, use `Enum.MY_ENUM.value`
+- **No wildcard imports**: Avoid `from module import *`
+- Avoid `**kwargs` and `*args` signatures: Explicit is better than implicit
+
+```bash
+# Format code
+ruff format src/ tests/
+
+# Check formatting
+ruff format --check src/ tests/
+
+# Lint
+ruff check src/ tests/
+
+# Lint and auto-fix
+ruff check --fix src/ tests/
+```
+
+The full working agreements (also used by AI coding agents) are in
+[AGENTS.md](AGENTS.md).
+
+## Pull Requests
+
+- Keep PRs focused on a single change.
+- Run the default test suite and Ruff before opening a PR.
+- Every PR must pass the CI pipeline and receive at least one approval from a
+  developer before it can be merged.
+- New components need config dataclasses, ConfigStore registration, tests, and
+  documentation updates (see the
+  [architecture docs](https://lorenzo-mazza.github.io/VersatIL/architecture/overview/)
+  for the component structure).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 [![PyPI](https://img.shields.io/pypi/v/versatil.svg)](https://pypi.org/project/versatil/)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://lorenzo-mazza.github.io/VersatIL)
 
-![VersatIL Logo](media/VersatIL_logo.png)
+![VersatIL Logo](https://raw.githubusercontent.com/Lorenzo-Mazza/VersatIL/main/media/VersatIL_logo.png)
 
 ### 🤯 The Paradox of Research Code
-Have you ever found yourself wondering: *"How would this Robot Policy perform if I simply swapped that ResNet18 for an EfficientNet, or just changed one term in the loss function?"*
+Have you ever found yourself wondering: *"How would this Robot Policy perform if I simply swapped that ResNet18 vision encoder for an EfficientNet, or just changed the KL divergence term in the loss function for a Maximum Mean Discrepancy?"*
 
 So you clone the repo to try it out. You wrestle with a `requirements.txt` from 2018 that demands CUDA 9.0 and a version of PyTorch that seemingly only exists on a floppy disk in a basement. You finally get the environment running, only to discover that the loss function implementation is tightly coupled to a string variable named `"dataset_v2_final_final"` deep in the training loop.
 
@@ -22,12 +22,12 @@ Or perhaps you have wandered through State-Of-The-Art codebases, staring blankly
 
 ### This ends with VersatIL. ⚡
 
-VersatIL is a modular, composable framework built with PyTorch that decouples the three pillars of imitation learning:
-**Data**, **Algorithm**, and **Architecture** into clean, reusable components.
+VersatIL is a modular, composable framework for doing offline Imitation Learning (behavioral cloning) built with PyTorch, that decouples its main pillars:
+**data**, **algorithm**, **network architecture** and **loss function** into clean, reusable components.
 
-Swap Behavioral Cloning for Diffusion or Flow Matching, replace a ResNet with a ViT or VLM backbone, or run your policy on a completely new dataset format. Compatible components can be freely swapped with config changes, no source code rewrites.
+Swap standard behavioral cloning for diffusion or flow matching, replace a CNN backbone with a ViT or a whole Vision-Language Model, or run your policy on a completely new dataset format. Compatible components can be freely swapped with config or command-line changes, no source code rewrites.
 
-Rapid experimentation, cleaner code, and true reusability across projects.
+Rapid experimentation, tested and reproducible code, and true reusability across projects.
 
 ### Core Principles
 - 🧑‍🔬 **Research-First Flexibility** — Unlike frameworks that focus on reimplementing and distributing specific SOTA policies, VersatIL gives you the modular building blocks to **create and benchmark your own novel architectures and algorithms** on any dataset.
@@ -39,21 +39,16 @@ Rapid experimentation, cleaner code, and true reusability across projects.
     * **[HuggingFace Transformers](https://github.com/huggingface/transformers)** for Language encoders, VLMs, and tokenizers.
     * **[HuggingFace Diffusers](https://github.com/huggingface/diffusers)** for diffusion schedulers.
     * **[Albumentations](https://albumentations.ai/)** for image augmentations.
-    * **[torchao](https://github.com/pytorch/ao)** for eager and PT2E quantization workflows, for both quantization-aware training and post-training quantization.
-- 💡 **Invent What Matters** For performance-critical components, we wrote a custom `src/versatil/models/layers` package in pure PyTorch. This includes optimized implementations of:
-    * [Attention](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) (PyTorch built-in SDPA Flash kernel dispatch).
-    * Conditional Flow Matching utilities and ODE integration.
-    * Positional Encodings (Sinusoidal, Learned, Rotary).
-    * Transformer variants (DETR, GPT, BERT, DiT).
-    * Modular Deep Neural Networks layers such as normalization, modulation, convolution, etc
-    * *Note: These are policy-agnostic and reusable in other projects.*
-- 🔒 **Explainability & Safety** – Strict interfaces, full type hints, Google-style docstrings, and runtime config validation.
-- 🧪 **Testing** – Unit and integration tests for every module, run in CI.
+    * **[torchao](https://github.com/pytorch/ao)** for post-training quantization (PT2E and quantize_() APIs).
+- 💡 **Invent What Matters** For performance-critical components, we wrote a custom `src/versatil/models/layers` package in pure PyTorch. *Note: These are policy-agnostic and reusable in other projects.*
+- 🔒 **Explainability & Reproducibility** – Strict interfaces, full type hints, Google-style docstrings, and runtime config validation.
+- 🧪 **Testing** – Comprehensive unit and integration tests for every module.
+
 
 ### Paper Reproducibility Instructions
 
 Paper-specific instructions for reproducing reported experiments are collected in
-the [Papers Reproducibility Instructions](docs/papers-reproducibility-instructions/index.md)
+the [Papers Reproducibility Instructions](https://lorenzo-mazza.github.io/VersatIL/papers-reproducibility-instructions/)
 docs section. These notes list the datasets, local path setup, environment
 variables, and Hydra configs used for each paper.
 
@@ -61,15 +56,7 @@ variables, and Hydra configs used for each paper.
 
 ## 🚀 Installation
 
-**Prerequisites:**
-- Python 3.13 or 3.14 — supported by `pyproject.toml` (`requires-python = ">=3.13,<3.15"`).
-- NVIDIA driver compatible with CUDA 13.0 PyTorch wheels, only when installing the `gpu` extra.
-
-**Setup:**
-### Option A: Install from PyPI
-
-Create a Python 3.13/3.14 environment with your preferred manager and install
-the package:
+VersatIL requires Python 3.13 or 3.14 and is available on PyPI:
 
 ```bash
 # With uv
@@ -83,120 +70,105 @@ mamba activate versatil
 pip install versatil
 ```
 
-The default PyPI PyTorch wheel runs on both CPU-only and CUDA machines. The
-dedicated CPU-only or CUDA 13.0 wheel sets are selected through the
-`--extra cpu` / `--extra gpu` flags of the source installs below.
+The default PyPI PyTorch wheel runs on both CPU-only and CUDA machines. For
+source installs — developing VersatIL, running the test suite, selecting the
+dedicated CPU-only or CUDA 13.0 PyTorch wheel sets, or enabling ExecuTorch
+`.pte` export — see the
+[installation guide](https://lorenzo-mazza.github.io/VersatIL/getting-started/installation/).
 
-### Option B: Install from source into a Miniforge/Mamba environment
-Use a source install when you want to develop VersatIL itself or run the test
-suite. Follow the Miniforge instructions at https://github.com/conda-forge/miniforge
+---
 
-```bash
-# 1. Clone repository
-git clone https://github.com/Lorenzo-Mazza/VersatIL.git
-cd VersatIL
+## 🏁 Quick Start
 
-# 2. Create environment (use Mamba for faster installation)
-mamba env create -f environment.yml
-mamba activate versatil
-# To force Python 3.13 instead:
-# mamba create -n versatil python=3.13 pip
-# mamba activate versatil
-# python -m pip install uv
+### Environment Configuration
 
-# 3. Install dependencies into the active conda environment
-PYTHON_VERSION=3.14
-UV_PROJECT_ENVIRONMENT=$CONDA_PREFIX uv sync --python "$PYTHON_VERSION" --extra gpu
-# For CPU-only environments:
-# UV_PROJECT_ENVIRONMENT=$CONDA_PREFIX uv sync --python "$PYTHON_VERSION" --extra cpu
-# For Python 3.13, set PYTHON_VERSION=3.13.
-
-# 4. Install pre-commit hooks (formatting + linting on every commit)
-pre-commit install
-```
-
-### Option C: Install from source with uv directly
-This creates a project-local `.venv` and does not require conda, mamba, or
-Miniforge.
+VersatIL uses a `.env` file to configure machine-specific paths. Copy the example and customize:
 
 ```bash
-# 1. Install uv if it is not already available
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 2. Clone repository
-git clone https://github.com/Lorenzo-Mazza/VersatIL.git
-cd VersatIL
-
-# 3. Create the Python environment
-PYTHON_VERSION=3.14
-uv python install "$PYTHON_VERSION"
-uv venv --python "$PYTHON_VERSION"
-source .venv/bin/activate
-# For Python 3.13, set PYTHON_VERSION=3.13.
-
-# 4. Install dependencies
-uv sync --python "$PYTHON_VERSION" --extra gpu
-# For CPU-only environments:
-# uv sync --python "$PYTHON_VERSION" --extra cpu
-
-# 5. Install pre-commit hooks (formatting + linting on every commit)
-pre-commit install
+cp .env.example .env
 ```
-
-With both source options, `uv sync` installs the `dev` dependency group
-(pytest, pytest-cov, ruff, pre-commit) by default, so the environment is ready
-for development out of the box. Pass `--no-dev` for a runtime-only install.
-
-### Optional ExecuTorch Dependency for Edge Deployment
-
-**ExecuTorch for XNNPACK `.pte` export:** Python 3.13 environments can install
-ExecuTorch from PyPI through the optional extra:
 
 ```bash
-PYTHON_VERSION=3.13
-uv sync --python "$PYTHON_VERSION" --extra cpu --extra executorch
-# Use --extra gpu instead of --extra cpu when installing the CUDA PyTorch stack.
+VERSATIL_CHECKPOINT_DIR=/path/to/checkpoints      # Where model checkpoints are saved
+VERSATIL_ZARR_DIR=/path/to/zarr                   # Preprocessed Zarr datasets
+VERSATIL_CACHE_DIR=/path/to/cache                 # HuggingFace/torch model cache
+VERSATIL_LIBERO_LEROBOT_DIR=/path/to/libero       # Raw data, one variable per dataset
 ```
 
-The `executorch` extra is guarded by a Python marker, because the published
-ExecuTorch package currently declares `requires-python = ">=3.10,<3.14"`.
-Python 3.14 environments need an ExecuTorch package built from source in the
-active `versatil` environment:
+The full variable list is in the [installation guide](https://lorenzo-mazza.github.io/VersatIL/getting-started/installation/#environment-configuration).
+
+### Available Benchmarks
+
+Ready-to-use end-to-end configs are organized by dataset under `src/versatil/hydra_configs/end_to_end_training_runs/`, and every simulated benchmark ships a ZMQ server wrapper for rolling out trained policies:
+
+| Benchmark | Configs | Data | Sim Server | Notes |
+|---|---|---|---|---|
+| [Bowel Retraction](https://arxiv.org/abs/2601.21971) | `bowel_retraction/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_bowel_grasping) | — | Real-world UR5e surgical dataset; language and depth variants included. |
+| [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO) (HDF5) | `libero_hdf5/` | [libero-project.github.io](https://libero-project.github.io/datasets) | [simulation_libero](https://github.com/nct-tso-robotics/simulation_libero) | Original HDF5 format with 128x128 (flipped) images. |
+| [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO) (LeRobot) | `libero_lerobot/` | [HF Hub](https://huggingface.co/datasets/lerobot/libero) | [simulation_libero](https://github.com/nct-tso-robotics/simulation_libero) | LeRobot format with OpenVLA filtered demonstrations and 256x256 images. |
+| [LIBERO+](https://github.com/sylvestf/LIBERO-plus) | `libero_plus/` | [HF Hub](https://huggingface.co/datasets/Sylvest/libero_plus_lerobot) | [simulation_libero_plus](https://github.com/nct-tso-robotics/simulation_libero_plus) | Extended LIBERO dataset. |
+| [MetaWorld MT50](https://github.com/Farama-Foundation/Metaworld) | `metaworld/` | [HF Hub](https://huggingface.co/datasets/lerobot/metaworld_mt50) | [simulation_metaworld](https://github.com/nct-tso-robotics/simulation_metaworld) | Multi-task benchmark (MT50 variant). |
+| [PushT](https://github.com/real-stanford/diffusion_policy/tree/main/diffusion_policy/env/pusht) | `pusht/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_pusht_lerobot) | [simulation_pusht](https://github.com/nct-tso-robotics/simulation_pusht) | LeRobot wrapper of the original PushT benchmark used by Diffusion Policy. |
+| [Block Pushing](https://github.com/google-research/ibc/tree/master/environments/block_pushing) | `block_pushing/` | [relative](https://huggingface.co/datasets/nct-tso/robotics_blockpush_relative_lerobot), [absolute](https://huggingface.co/datasets/nct-tso/robotics_blockpush_absolute_lerobot) | [simulation_block_push](https://github.com/nct-tso-robotics/simulation_block_push) | LeRobot wrappers of the original IBC/Diffusion Policy BlockPush dataset; relative and absolute action variants. |
+| [Kitchen](https://github.com/google-research/relay-policy-learning) | `kitchen/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_kitchen_lerobot) | [simulation_kitchen](https://github.com/nct-tso-robotics/simulation_kitchen) | LeRobot wrapper of the original Franka Kitchen dataset from relay-policy-learning. |
+| [Multimodal Ant](https://github.com/jayLEE0301/vq_bet_official/tree/main/envs/antenv) | `ant/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_multimodal_ant_lerobot) | [simulation_multimodal_ant](https://github.com/nct-tso-robotics/simulation_multimodal_ant) | LeRobot wrapper of the original multimodal Ant navigation dataset. |
+| [UR3 Block Push](https://github.com/jayLEE0301/vq_bet_official/tree/main/envs/ur3) | `ur3/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_ur3_blockpush_lerobot) | [simulation_ur3_block_push](https://github.com/nct-tso-robotics/simulation_ur3_block_push) | LeRobot wrapper of the original UR3 block-push dataset from VQ-BeT. |
+| Synthetic | `synthetic/` | Generated on demand | — | Lightweight synthetic multimodal benchmark configs. |
+
+The LIBERO server wrapper also supports [LIBERO-PRO](https://github.com/Zxy-MLlab/LIBERO-PRO/tree/master) evaluation.
+
+Each config is self-contained, just point to your data path and run! 
+
+### Training Your First Model
 
 ```bash
-cd ..
-git clone https://github.com/pytorch/executorch.git
-cd executorch
-git submodule update --init --recursive
+# Train ACT on bowel retraction dataset
+python -m versatil.endpoints.train --config-name end_to_end_training_runs/bowel_retraction/act
 
-# Build dependencies must be present because --no-build-isolation is used.
-pip install "cmake>=3.24,<4.0.0" "packaging>=24.2" pyyaml "setuptools>=77.0.3" wheel zstd certifi ninja
-
-SITE_PACKAGES=$(python - <<'PY'
-import site
-print(site.getsitepackages()[0])
-PY
-)
-# CUDA and OpenVINO must be disabled explicitly
-# because setup.py auto-enables them when nvcc / Linux are detected; the LLM
-# kernels are preset defaults this deployment does not need.
-CMAKE_PREFIX_PATH="$SITE_PACKAGES" \
-CMAKE_BUILD_PARALLEL_LEVEL=8 \
-CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=OFF -DEXECUTORCH_BUILD_OPENVINO=OFF -DEXECUTORCH_BUILD_KERNELS_LLM=OFF -DEXECUTORCH_BUILD_KERNELS_LLM_AOT=OFF" \
-python -m pip install . --no-build-isolation --ignore-requires-python --no-deps -v
-
-cd ../versatil
-
-# Runtime dependencies are skipped by --no-deps; install the AoT set manually.
-pip install flatbuffers "ruamel.yaml" sympy tabulate pytorch-tokenizers \
-    expecttest hypothesis kgb parameterized
-
-# Now all ExecuTorch-gated tests should pass.
-pytest -m requires_executorch -o addopts=""
+# Train ACT on LIBERO dataset, overriding any parameter from the CLI
+python -m versatil.endpoints.train --config-name end_to_end_training_runs/libero_hdf5/act \
+    task.dataloader.batch_size=64 training.optimizer.lr=1e-4
 ```
 
-`python -m pip check` can still report a `scikit-learn` metadata conflict in
-Python 3.14 environments. The XNNPACK export path works with the built package.
+CLI overrides, checkpointing, resuming, and WandB tracking are covered in the [training guide](https://lorenzo-mazza.github.io/VersatIL/getting-started/training/).
+
+### 🧩 Available Components
+
+#### Encoders
+
+Observations can be encoded with, in principle, any model hosted on [timm](https://github.com/huggingface/pytorch-image-models) or [HF Transformers](https://github.com/huggingface/transformers) — CNNs, ViTs, language models, and VLMs alike:
+
+- **RGB**: any timm vision backbone, producing spatial feature maps (ResNet, ConvNeXt, Swin, ...) or token sequences (ViT, DINOv2/v3, SigLIP, ...).
+- **Depth and RGB-D**: single-channel depth backbones and cross-modal RGB-D encoders with geometric attention.
+- **Language and VLM**: text embedding models (BERT-family, EmbeddingGemma, Qwen Embedding, ...) and image-text models (CLIP, SigLIP, ...) for language-conditioned policies.
+- **Proprioception**: robot state encoders.
+
+Features from multiple cameras and modalities can then be fused before decoding — by concatenation, MLP projection, or cross-attention. Adding a new backbone is usually a one-line Enum entry mapping to a timm or HF Transformers model name; fully custom encoders just subclass a small base interface. The complete encoder catalog is in the [encoding docs](https://lorenzo-mazza.github.io/VersatIL/architecture/encoding/).
+
+#### Algorithms
+
+The same decoder architecture can be trained with behavioral cloning, denoising diffusion, or flow matching, and any of these can be wrapped with a variational latent space learned through configurable priors and posteriors — see the [algorithms docs](https://lorenzo-mazza.github.io/VersatIL/architecture/algorithms/).
+
+#### Action Decoders
+
+VersatIL reproduces the main policy architectures from the offline imitation-learning/behavioral cloning literature:
+
+| Policy | Paper | Available |
+|---|---|:---:|
+| ACT | [arXiv:2304.13705](https://arxiv.org/abs/2304.13705) | ✅ |
+| Diffusion Policy | [arXiv:2303.04137](https://arxiv.org/abs/2303.04137) | ✅ |
+| DiT-Block Policy | [arXiv:2410.10088](https://arxiv.org/abs/2410.10088) | ✅ |
+| LACT | [arXiv:2605.22493](https://arxiv.org/abs/2605.22493) | ✅ |
+| MoE-ACT | [arXiv:2601.21971](https://arxiv.org/abs/2601.21971) | ✅ |
+| OpenVLA | [arXiv:2406.09246](https://arxiv.org/abs/2406.09246) | ✅ |
+| OpenVLA-OFT | [project page](https://openvla-oft.github.io/) | ✅ |
+| π0 | [arXiv:2410.24164](https://arxiv.org/abs/2410.24164) | ✅ |
+| π0-FAST | [arXiv:2501.09747](https://arxiv.org/abs/2501.09747) | ✅ |
+| π0.5 | [arXiv:2504.16054](https://arxiv.org/abs/2504.16054) | ✅ |
+| SmolVLA | [arXiv:2506.01844](https://arxiv.org/abs/2506.01844) | ✅ |
+
+
+**But it doesn't stop here!** Beyond the literature presets, generic building blocks (bidirectional, autoregressive, and diffusion action transformers, swappable VLM backbones inside the VLA decoders, plus a Mixture-of-Experts wrapper applicable to any decoder), tuning paradigms (custom LoRA, multi-stage training, custom objective functions) and algorithm sweeping (swap algorithms from the same class, or change the diffusion/flow solver, etc.) enable you to design new architectures. You can also easily implement fully custom decoders by just subclassing [`ActionDecoder`](src/versatil/models/decoding/decoders/base.py). The complete decoder catalog is in the [decoders docs](https://lorenzo-mazza.github.io/VersatIL/architecture/decoders/).
 
 ---
 
@@ -216,7 +188,22 @@ OmegaConf provides:
 - **Config Safety:** All configs are typed Dataclasses. If you pass a string where an int is expected, or forget a mandatory field, the run fails immediately at startup—not 2 hours into training.
 - **Smart merging** — Config classes define defaults that automatically fill missing values when merging multiple files.
 
-Together, this means you can create new experiments by overriding only the parameters that change — no need to write complete YAML files for every run.
+Together, this means you can create new experiments by overriding only the parameters that change. Forget about writing verbose YAML files for every single run you want to benchmark — an end-to-end experiment is just a list of reusable blocks:
+
+```yaml
+# end_to_end_training_runs/bowel_retraction/act.yaml (excerpt)
+defaults:
+  - /task/dataset_schema: bowel_retraction_v2   # Raw data format
+  - /task/dataloader: bowel_retraction           # Batch size, torch workers, augmentation
+  - /task/action_space: deltas_cf_pos_gripper_phase
+  - /task/observation_space: stereo_rgb
+  - /policy/encoding_pipeline: stereo_rgb        # Encoder + fusion config
+  - /policy/decoder: act_default                 # Action decoder architecture
+  - /policy/algorithm: bc_with_vae_gaussian      # Learning algorithm
+  - /policy/loss: regression_gripper_kl          # Loss composition
+```
+
+Every block is validated against a typed dataclass at startup — see the [configuration guide](https://lorenzo-mazza.github.io/VersatIL/getting-started/configuration/) for the full system.
 
 ---
 #### 🗄️ Dataset Schema (Ingestion)
@@ -233,10 +220,10 @@ Instead, VersatIL handles this with a two-stage approach:
    | Custom                                                | Subclass [`DatasetSchema`](src/versatil/data/raw/schemas/base.py) | Any                     |
 
 2. **Zarr Store Creation**
-   Zarr [https://zarr.readthedocs.io/en/stable/]  provides fast, compressed, chunked storage with NumPy-like access.
-   - Created **automatically** on first training run if missing — no separate preprocessing script needed.
+   [Zarr](https://zarr.readthedocs.io/en/stable/) provides fast, compressed, chunked storage with NumPy-like access.
+   - Created **automatically** on first training run if missing. No separate preprocessing script needed.
    - Decouples raw storage from training-optimized layout.
-   - Raw keys vs pipeline keys: Raw data formats use their own naming (e.g., LIBERO LeRobot dataset uses `observation.images.image`, LIBERO original HDF5 dataset uses `agentview_image`). During zarr creation, these *raw camera keys* ([`RawCameraKey`](src/versatil/data/constants.py)) are remapped to standardized *pipeline camera keys* ([`Cameras`](src/versatil/data/constants.py)) via `RAW_TO_CAMERA_MAPPING`. After zarr creation, only pipeline keys exist — the rest of the codebase (training, inference, validation) never sees raw format keys. This separation is defined in `src/versatil/data/constants.py`, so adding a new raw data format only takes a new [`RawCameraKey`](src/versatil/data/constants.py) entry and its mapping — the training and inference pipeline stays untouched.
+   - Format-specific keys (e.g. `observation.images.image`, `agentview_image`) are remapped to standardized pipeline keys during ingestion, so training and inference never see raw format naming — see the [data docs](https://lorenzo-mazza.github.io/VersatIL/architecture/data/).
 
 ---
 
@@ -260,7 +247,7 @@ Uniform across all Zarr datasets:
 - Preprocessing (normalization, augmentation, tokenization)
 - Batching via PyTorch DataLoader
 
-Actions can be **precomputed** (stored in Zarr) or computed **on-the-fly** during batching(e.g., deltas from consecutive states).
+Actions can be **precomputed** (stored in Zarr) or computed **on-the-fly** during batching (e.g., deltas from consecutive states).
 
 ---
 
@@ -272,12 +259,10 @@ A robot policy is built from four decoupled components, orchestrated by the [`Po
 into a unified representation.
 2.  🧮 **Algorithm:** The learning paradigm that defines how to train the policy. This can be:
 - Standard Behavioral Cloning (supervised learning of actions given observations)
-- Generative approaches through Denoising Score Matching such as Diffusion and Flow Matching.
-- Variational approaches that add a learned latent variables to any base algorithm. The latent variable can be learned through different kinds of prior-posterior schemes,
- which will determine the nature of the latent space.
-3) 🕹️ **Action Decoder:** The neural architecture that decodes the features into robot actions. This can be a Transformer-based architecture or a UNet-based architecture.
-We provide a set of standard decoders such as the Action Chunking Transformer (ACT) or the DiT-Block Policy from the literature. More information on the available decoders can be found below.
-We additionally support a Mixture-Of-Experts (MoE) wrapper, which can be used on top of any decoder to copy the architecture across multiple experts and learn a gating network to select which expert to use at inference time.
+- Generative approaches such as Diffusion and Flow Matching.
+- Variational approaches that add a learned latent variable to any base algorithm. The latent variable can be learned through different kinds of prior-posterior schemes, which will determine the nature of the latent space.
+3. 🕹️ **Action Decoder:** The neural architecture that decodes the features into robot actions. 
+We provide a set of factory decoders which comprise some of the SOTA architectures of recent years in the field of offline IL, from the Action Chunking Transformer (ACT), to the Diffusion Policy, until more recent Vision-Language-Action models. More information on the available decoders can be found below.
 4.  📉 **Loss Module:** A composable loss module that defines the objective function to optimize during training. This can be a simple regression loss (MSE) or a more complex loss that combines multiple terms (e.g. action regression + KL divergence for variational algorithms).
 
 ---
@@ -285,39 +270,24 @@ We additionally support a Mixture-Of-Experts (MoE) wrapper, which can be used on
 
 #### ⚡ Training Engine
 Powered by **PyTorch Lightning**:
-* Automatic handling of loops, distributed training, and checkpointing.
-* **WandB Integration:** Tracks metrics, gradients, EMA decay, and latent visualizations.
-* **Callbacks:** EMA weights, gradient norm logging, t-SNE plots.
+* Automatic handling of training and checkpointing.
+* **WandB Integration:** Tracks in real-time metrics and visualizations.
+* **Callbacks:** Pluggable training-loop hooks, from EMA weights to latent-space visualizations.
 
 ---
 ### 🚀 Post-Training
 
 #### 🔌 Inference
 
-The inference pipeline is transport-agnostic: communication with any environment server (real robot, simulation, or custom) is abstracted behind [`ObservationTransport`](src/versatil/inference/protocol.py) and [`ActionTransport`](src/versatil/inference/protocol.py) Python protocols. Any object satisfying these protocols works — ZMQ, HTTP, etc.
+The inference pipeline is transport-agnostic: communication with any environment server (real robot or simulation) is abstracted behind [`ObservationTransport`](src/versatil/inference/protocol.py) and [`ActionTransport`](src/versatil/inference/protocol.py) Python protocols. Any object satisfying these protocols works (ZMQ, HTTP, etc).
 
 The built-in ZMQ implementation uses our two PyPI packages:
-- [**tso-robotics-sockets**](https://pypi.org/project/tso-robotics-sockets/): Generic ZMQ socket client/server with protocol keys (`ServerRoute`, `InferenceRequestKey`, `CompressionType`).
-- [**versatil-constants**](https://pypi.org/project/versatil-constants/): Shared domain constants for action/observation message passing (`ActionComponent`, `ActionMetadataField`, `ObsKey`, `GripperType`, `OrientationRepresentation` and dataset/benchmark specific message keys).
+- [**tso-robotics-sockets**](https://pypi.org/project/tso-robotics-sockets/): Generic ZMQ socket client/server.
+- [**versatil-constants**](https://pypi.org/project/versatil-constants/): Shared constants defining the observation/action message format.
 
-Both libraries are server-agnostic — they define the message format, not the server implementation. Any server that speaks the protocol can be integrated by implementing the transport protocols.
+Both libraries are server-agnostic, i.e. they define the message format but not the server implementation. For custom setups, you just need to implement the transport protocols, [`ObservationTransport`](src/versatil/inference/protocol.py) and [`ActionTransport`](src/versatil/inference/protocol.py), and couple it with your custom server.
 
-The built-in ZMQ transport works for both simulation and real hardware — the dataset format is fully decoupled from the transport layer. For custom setups, implement the [`ObservationTransport`](src/versatil/inference/protocol.py) and [`ActionTransport`](src/versatil/inference/protocol.py) protocols with any transport mechanism.
-
-##### Simulation Servers
-
-We provide ZMQ server wrappers for common robot learning simulators, so VersatIL policies can be rolled out without extra glue code:
-
-| Simulator | Original | ZMQ Server Wrapper |
-|---|---|---|
-| LIBERO / LIBERO-PRO | [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO), [LIBERO-PRO](https://github.com/Zxy-MLlab/LIBERO-PRO/tree/master) | [simulation_libero](https://github.com/nct-tso-robotics/simulation_libero) |
-| LIBERO+ | [GitHub](https://github.com/sylvestf/LIBERO-plus) | [simulation_libero_plus](https://github.com/nct-tso-robotics/simulation_libero_plus) |
-| MetaWorld | [GitHub](https://github.com/Farama-Foundation/Metaworld) | [simulation_metaworld](https://github.com/nct-tso-robotics/simulation_metaworld) |
-| PushT | [Diffusion Policy PushT](https://github.com/real-stanford/diffusion_policy/tree/main/diffusion_policy/env/pusht) | [simulation_pusht](https://github.com/nct-tso-robotics/simulation_pusht) |
-| Franka Kitchen | [relay-policy-learning](https://github.com/google-research/relay-policy-learning) | [simulation_kitchen](https://github.com/nct-tso-robotics/simulation_kitchen) |
-| BlockPush | [IBC BlockPushing](https://github.com/google-research/ibc/tree/master/environments/block_pushing) | [simulation_block_push](https://github.com/nct-tso-robotics/simulation_block_push) |
-| UR3 BlockPush | [VQ-BeT UR3](https://github.com/jayLEE0301/vq_bet_official/tree/main/envs/ur3) | [simulation_ur3_block_push](https://github.com/nct-tso-robotics/simulation_ur3_block_push) |
-| Multimodal Ant | [VQ-BeT AntEnv](https://github.com/jayLEE0301/vq_bet_official/tree/main/envs/antenv) | [simulation_multimodal_ant](https://github.com/nct-tso-robotics/simulation_multimodal_ant) |
+We also provide ZMQ server wrappers for common robot learning simulators, so VersatIL policies can be rolled out without extra glue code — each benchmark in the [Available Benchmarks](#available-benchmarks) table links its server wrapper in the Sim Server column.
 
 ---
 
@@ -333,445 +303,82 @@ python -m versatil.endpoints.explain \
     max_samples=16
 ```
 
-Heatmap overlays (and optionally raw tensors) are written next to the checkpoint. See the [explainability guide](docs/architecture/explainability.md) for sources, targeting, and output formats.
+Heatmap overlays (and optionally raw tensors) are written next to the checkpoint. See the [explainability guide](https://lorenzo-mazza.github.io/VersatIL/architecture/explainability/) for sources, targeting, and output formats.
 
 ---
 
 
 #### 📦 Quantization and Post-Training Compression
 
-**What is post-training quantization?**
-Post-training quantization (PTQ) converts trained floating-point model weights and activations to lower-precision integer representations (e.g., INT8). This reduces memory footprint, improves cache utilization, and enables hardware-accelerated integer arithmetic — typically achieving inference speedup on x86 CPUs with minimal accuracy loss. PTQ is done after training. Static quantization uses a small calibration dataset to determine optimal activation ranges per layer; dynamic quantization computes ranges on-the-fly at inference time and needs no calibration.
-**What is quantization-aware-training?**
-Quantization-aware training inserts fake quantizers between layers of the neural policy to mimic the information loss that the policy will experience at deployment time after PTQ. In this way, the policy learns a mapping that is robust to PTQ-induced information loss, improving downstream performance.
-**How VersatIL implements quantization:**
-VersatIL's quantization package is built upon PyTorch's native quantization library `torchao`, which supports two types of quantization workflows: eager quantization (mainly used for dynamic quantization of Large Language Models, int8 to int2 support, linear layers only) and PyTorch 2 Export quantization (mainly used for static quantization, int8 only, linear and convolutional layers). Both workflows plug directly into policy training and deployment. See the [quantization guide](docs/architecture/quantization.md) for more details about these quantization workflows.
-
-**What is post-training compression?**
-The post-training compression (PTC) pipeline that turns a trained policy checkpoint into a deployment artifact for edge or resource-constrained hardware. A PTC run can export a floating-point model, apply pruning, quantize the policy, and save either a Torch Export `.pt2` artifact or an ExecuTorch `.pte` artifact.
-
-
-**How VersatIL implements PTC:**
-
-The compression pipeline is configurable via Hydra and supports three complementary techniques applied sequentially:
-
-1. **Preparation**: Frozen BatchNorm replacement and Conv+BN weight folding — standard pre-quantization layer fusion that merges batch normalization parameters into convolution weights.
-
-2. **Pruning**: Weight pruning to introduce sparsity before quantization. Supports both unstructured (global L1 magnitude) and structured (per-channel Lp-norm) pruning, composable sequentially, e.g. structured pruning followed by unstructured pruning on the same module.
-
-3. **Quantization workflow**: One workflow is selected per policy:
-   - **No quantization**: `quantization: null` exports the floating-point policy.
-   - **Eager quantization**: Uses the [`torchao.quantization.quantize_()` API](https://docs.pytorch.org/ao/stable/api_reference/generated/torchao.quantization.quantize_.html#torchao.quantization.quantize_) before export.
-   - **PT2E** (PyTorch 2 Export): Exports the policy with `torch.export`, then applies PT2E prepare, optional calibration, and convert.
-
-
-**Per-module targeting:**
-
-Compression targets configure preparation and pruning globally or per module. Quantization targets live inside the selected workflow under `quantization.targets`, where each [`QuantizationModuleTarget`](src/versatil/quantization/module_target.py) can carry a module-specific quantization config. Target paths must exist in the policy and must not overlap.
-
-**Deployment backends:**
-
-The `deployment_backend` config field selects the artifact format and lowering step for edge deployment. As of now, two backends are supported:
-- `TorchInductorBackend`, for running on X86 CPUs.
-- `ExecutorchXNNPACKBackend` for running on ARM and X86 mobile CPUs. 
-
-**Compressed inference:**
-
-Compressed models are loaded by [`CompressedPolicyRuntime`](src/versatil/inference/policy_runtime/compressed_runtime.py). Torch Export `.pt2` artifacts run through PyTorch and can be compiled with `torch.compile` when appropriate. ExecuTorch `.pte` artifacts run through the ExecuTorch adapter on CPU.  Currently, compressed models are not fully standalone: they still require a complete VersatIL installation, including its dependencies. Since this is not ideal for edge deployment, self-contained edge-device inference runtime is currently under development.
+VersatIL's quantization package is built upon PyTorch's native quantization library `torchao` and supports quantization-aware training as well as eager and PT2E post-training quantization, targeting the whole policy or individual modules. The post-training compression pipeline turns a trained policy checkpoint into a deployment artifact for edge or resource-constrained hardware: a PTC run can export a floating-point model, apply pruning, quantize the policy, and save either a Torch Export `.pt2` artifact (x86 CPUs) or an ExecuTorch `.pte` artifact (ARM and x86 mobile CPUs). Background and full configuration are covered in the [quantization guide](https://lorenzo-mazza.github.io/VersatIL/architecture/quantization/) and the [compression guide](https://lorenzo-mazza.github.io/VersatIL/architecture/post_training_compression/).
 
 ---
 
-## 🚀 Quick Start
+## 🤝 Contributing
 
-### Environment Configuration
-
-VersatIL uses a `.env` file to configure machine-specific paths. Copy the example and customize:
+Contributions are welcome! Install from source, then verify your setup:
 
 ```bash
-cp .env.example .env
-```
-
-Edit `.env` with your paths:
-
-```bash
-# Storage paths
-VERSATIL_CHECKPOINT_DIR=/path/to/checkpoints      # Where model checkpoints are saved
-VERSATIL_ZARR_DIR=/path/to/zarr                   # Preprocessed Zarr datasets
-VERSATIL_CACHE_DIR=/path/to/cache                 # HuggingFace/torch model cache
-
-# Dataset paths (set only the ones you use)
-VERSATIL_BOWEL_RETRACTION_DIR=/path/to/bowel_retraction
-VERSATIL_LIBERO_HDF5_DIR=/path/to/libero/datasets
-VERSATIL_LIBERO_LEROBOT_DIR=/path/to/libero_lerobot
-VERSATIL_LIBERO_PLUS_LEROBOT_DIR=/path/to/libero_plus_lerobot
-VERSATIL_METAWORLD_LEROBOT_DIR=/path/to/metaworld_lerobot
-VERSATIL_PUSHT_LEROBOT_DIR=/path/to/pusht_lerobot
-VERSATIL_BLOCK_PUSHING_LEROBOT_DIR=/path/to/block_pushing_lerobot_rel
-VERSATIL_BLOCK_PUSHING_LEROBOT_ABS_DIR=/path/to/block_pushing_lerobot_abs
-VERSATIL_KITCHEN_LEROBOT_DIR=/path/to/kitchen_lerobot
-VERSATIL_ANT_LEROBOT_DIR=/path/to/ant_lerobot
-VERSATIL_UR3_LEROBOT_DIR=/path/to/ur3_lerobot
-
-# Weights & Biases (optional)
-WANDB_PROJECT=versatil
-WANDB_ENTITY=your-team
-```
-
-These variables are referenced in Hydra configs via OmegaConf resolvers (e.g., `${checkpoint_dir:bowel_retraction}`).
-
-### Available Training Configs
-
-Ready-to-use end-to-end configs are organized by dataset under `src/versatil/hydra_configs/end_to_end_training_runs/`:
-
-| Dataset | Path | Data Link | Notes                                                                   |
-|---|---|---|-------------------------------------------------------------------------|
-| [Bowel Retraction](https://arxiv.org/abs/2601.21971) | `bowel_retraction/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_bowel_grasping) | Original real-world UR5e surgical robotics dataset release. Language and depth variants included. |
-| [LIBERO](https://libero-project.github.io/datasets) (HDF5) | `libero_hdf5/` | [libero-project.github.io](https://libero-project.github.io/datasets) | Original HDF5 format with 128x128 (flipped) images.                     |
-| [LIBERO](https://huggingface.co/datasets/lerobot/libero) (LeRobot) | `libero_lerobot/` | [HF Hub](https://huggingface.co/datasets/lerobot/libero) | LeRobot format with OpenVLA filtered demonstrations and 256x256 images. |
-| [LIBERO+](https://huggingface.co/datasets/Sylvest/libero_plus_lerobot) | `libero_plus/` | [HF Hub](https://huggingface.co/datasets/Sylvest/libero_plus_lerobot) | Extended LIBERO dataset.                                                |
-| [MetaWorld MT50](https://huggingface.co/datasets/lerobot/metaworld_mt50) | `metaworld/` | [HF Hub](https://huggingface.co/datasets/lerobot/metaworld_mt50) | Multi-task benchmark (MT50 variant).                                    |
-| PushT | `pusht/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_pusht_lerobot) | LeRobot wrapper of the original PushT benchmark used by Diffusion Policy. |
-| Block Pushing | `block_pushing/` | [relative](https://huggingface.co/datasets/nct-tso/robotics_blockpush_relative_lerobot), [absolute](https://huggingface.co/datasets/nct-tso/robotics_blockpush_absolute_lerobot) | LeRobot wrappers of the original IBC/Diffusion Policy BlockPush dataset; relative and absolute action variants. |
-| Kitchen | `kitchen/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_kitchen_lerobot) | LeRobot wrapper of the original Franka Kitchen dataset from relay-policy-learning. |
-| Multimodal Ant | `ant/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_multimodal_ant_lerobot) | LeRobot wrapper of the original multimodal Ant navigation dataset. |
-| UR3 Block Push | `ur3/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_ur3_blockpush_lerobot) | LeRobot wrapper of the original UR3 block-push dataset from VQ-BeT. |
-| Synthetic | `synthetic/` | Generated on demand | Lightweight synthetic multimodal benchmark configs. |
-
-Each config is self-contained — just point to your data path and run.
-
-### Training Your First Model
-
-**1. Default Training:**
-```bash
-# Train ACT on bowel retraction dataset
-python -m versatil.endpoints.train --config-name end_to_end_training_runs/bowel_retraction/act
-
-# Train ACT on LIBERO dataset
-python -m versatil.endpoints.train --config-name end_to_end_training_runs/libero_hdf5/act
-```
-
-**2. Override Configuration:**
-```bash
-# Change batch size
-python -m versatil.endpoints.train \
-    --config-name end_to_end_training_runs/bowel_retraction/act \
-    task.dataloader.batch_size=64
-
-# Disable EMA
-python -m versatil.endpoints.train \
-    --config-name end_to_end_training_runs/bowel_retraction/act \
-    training.use_ema=false
-
-# Change learning rate
-python -m versatil.endpoints.train \
-    --config-name end_to_end_training_runs/bowel_retraction/act \
-    training.optimizer.lr=1e-4
-```
-
-**3. Distributed Training (SLURM):**
-Not supported yet
-
----
-
-## 🏗️ Architecture
-
-### Policy Composition
-
-The [`Policy`](src/versatil/models/policy.py) class orchestrates three stages:
-
-```python
-# 1. Encode observations
-features = encoding_pipeline(observations)  # Multi-modal → unified representation
-
-# 2. Decode actions (algorithm orchestrates the decoder internally)
-predictions = algorithm.forward(
-    network=decoder,       # Algorithm receives decoder as a callable
-    features=features,
-    actions=ground_truth,  # During training
-)
-
-# 3. Compute loss
-loss = loss_module(predictions, targets)
-```
-
-
-### Feature Naming Contract
-
-VersatIL relies on strict naming conventions to wire encoders to decoders automatically. Instead of manually passing tensors, we match strings.
-
-**The Rule:** `feature_name = "{encoder_name}_{output_key}"`
-
-If you define an RGB encoder named `left_eye`, it produces:
-* `left_eye_rgb` (The spatial features)
-
-If you define a proprioception encoder named `robot_state`, it produces:
-* `robot_state_proprio` (The flat features)
-
-For multimodal encoders that produce multiple outputs (e.g. Vision-Language models), each output gets its own prefixed name.
-If you define a VLM encoder named `vlm_model`, it produces:
-* `vlm_model_rgb` (Image features)
-* `vlm_model_language` (Text features)
-
-For multi-camera encoders that share weights across cameras, the modality is followed by the camera key separated by a colon.
-If you define an RGB encoder named `stereo` with two input cameras keyed `key_1` and `key_2`, it produces:
-* `stereo_rgb:key_1` (Features from camera `key_1`)
-* `stereo_rgb:key_2` (Features from camera `key_2`)
-
-**Why strict naming?**
-It prevents shape mismatches silently propagating. The [`Policy`](src/versatil/models/policy.py) class validates shapes at initialization. If your Decoder expects a **FLAT** feature (1D)
-but you feed it **SPATIAL** (3D) (Channel, Height, Width) features from a spatial vision backbone, the code raises a `ValueError` immediately—before training starts.
-
-
-**Fusion outputs** specify `output_name` directly, due to their multi-input nature.
-```python
-fusion = AttentionFusion(
-    input_features=["left_eye_rgb", "right_eye_rgb"],  # Use encoder feature names
-    output_name="fused_visual"  # Direct name (no prefix)
-)
-```
-
-
-**Decoder inputs** require `input_keys` from the encoders or fusion outputs.
-
-
-## 🧩 Available Components
-
-### Encoders
-
-- **RGB** via [timm](https://github.com/huggingface/pytorch-image-models)
-  - [`SpatialRGBEncoder`](src/versatil/models/encoding/encoders/rgb/spatial.py): spatial feature maps — ResNet, EfficientNet, ConvNeXt, MobileNet, EdgeNeXt, Swin, TinyViT, ...
-  - [`FlatRGBEncoder`](src/versatil/models/encoding/encoders/rgb/flat.py): token sequences — ViT, DINOv2, DINOv3, CLIP ViT, SigLIP, ...
-  - [`DinoV2SigLIPRGBEncoder`](src/versatil/models/encoding/encoders/rgb/dinov2_siglip.py): paired DINOv2+SigLIP patch-token features
-  - [`ConditionalCNNEncoder`](src/versatil/models/encoding/encoders/rgb/conditional_cnn.py): ResNet with FiLM conditioning
-- **Depth** via [timm](https://github.com/huggingface/pytorch-image-models)
-  - [`SpatialDepthEncoder`](src/versatil/models/encoding/encoders/depth/spatial.py): single-channel spatial feature maps
-- **Cross-Modal RGBD**
-  - [`DFormerEncoder`](src/versatil/models/encoding/encoders/cross_modal/rgbd/dformerv2.py): RGB-D encoder with Geometric Attention ([paper](https://arxiv.org/abs/2504.04701), [pretrained weights](https://huggingface.co/bbynku/DFormerv2), [docs](https://lorenzo-mazza.github.io/VersatIL/architecture/encoding/))
-  - [`GeometricRGBDEncoder`](src/versatil/models/encoding/encoders/cross_modal/rgbd/geometric_rgbd.py): Custom lightweight geometric depth encoder
-- **Vision Language Model (VLM) encoders** via [HF Transformers](https://github.com/huggingface/transformers):
-  - [`VLMEncoder`](src/versatil/models/encoding/encoders/cross_modal/vision_language/vlm_encoder.py): encoder-pipeline module for image-text embedding models, e.g. CLIP and SigLIP.
-- **Language encoders** via [HF Transformers](https://github.com/huggingface/transformers): BERT, DistilBERT, MiniLM, EmbeddingGemma, Qwen Embedding, BGE, E5, ALBERT, RoBERTa, DeBERTa, ...
-- **Proprioceptive**: [`ProprioceptiveEncoder`](src/versatil/models/encoding/encoders/proprioceptive/base.py) — MLP for robot state
-
-Available encoder backbones are listed in `src/versatil/models/encoding/encoders/constants.py` ([`SpatialBackboneType`](src/versatil/models/encoding/encoders/constants.py), [`FlatBackboneType`](src/versatil/models/encoding/encoders/constants.py), [`DinoV2SigLIPBackboneType`](src/versatil/models/encoding/encoders/constants.py), [`LanguageEncoderType`](src/versatil/models/encoding/encoders/constants.py), [`ImageTextModelType`](src/versatil/models/encoding/encoders/constants.py)).
-They can be easily extended by either:
-- Adding new Enum values that map to timm or HF Transformers model names.
-- Implementing custom encoder classes that subclass [`Encoder`](src/versatil/models/encoding/encoders/unconditional.py) (or [`ConditionalEncoder`](src/versatil/models/encoding/encoders/conditional.py) for conditioned encoders).
-
-### Fusion
-
-- [`ConcatFusion`](src/versatil/models/encoding/fusion/concat.py) - Concatenation
-- [`MLPFusion`](src/versatil/models/encoding/fusion/mlp.py) - MLP projection after concat
-- [`AttentionFusion`](src/versatil/models/encoding/fusion/attention.py) - Cross-attention
-
-### Algorithms
-
-- [`BehavioralCloning`](src/versatil/models/decoding/algorithm/behavior_cloning.py) - Optimizes likelihood of expert actions via supervised learning
-- [`Diffusion`](src/versatil/models/decoding/algorithm/diffusion.py) - Generative modeling via Denoising Score Matching through Diffusion ([paper](https://arxiv.org/abs/2011.13456))
-- [`FlowMatching`](src/versatil/models/decoding/algorithm/flow_matching.py) - Flow-Based Generative Modeling via Continuous Normalizing Flows ([paper](https://arxiv.org/abs/2209.03003))
-- [`VariationalAlgorithm`](src/versatil/models/decoding/algorithm/variational.py) - Variational Inference wrapper to learn a latent space to use for any base algorithm
-
-### Variational Framework
-
-The [`VariationalAlgorithm`](src/versatil/models/decoding/algorithm/variational.py) wraps any base algorithm with a VAE-style latent space:
-
-- **Posterior Network** q(z|a,s): Encodes actions into latent z during training
-- **Prior Network** p(z|s): Samples latent z during inference (no access to actions)
-
-**Posterior Network types:**
-- [`VAETransformerEncoder`](src/versatil/models/decoding/latent/posterior/transformer_encoder.py) - Transformer encoder that learns a CLS token to predict latent mean and logvar of a conditional Gaussian posterior
-- [`VQPosteriorEncoder`](src/versatil/models/decoding/latent/posterior/vq_encoder.py) - Transformer posterior with residual vector quantization for discrete latent action codes
-
-**Prior Network types:**
-- [`GaussianPrior`](src/versatil/models/decoding/latent/prior/gaussian_prior.py) - Fixed Gaussian N(0,I) (standard VAE prior)
-- [`PriorTransformerEncoder`](src/versatil/models/decoding/latent/prior/transformer_encoder.py) - Learned conditional gaussian prior using a transformer encoder
-- [`DiTPrior`](src/versatil/models/decoding/latent/prior/dit_prior.py) - Multimodal prior trained via diffusion/flow matching
-- [`VampPrior`](src/versatil/models/decoding/latent/prior/vamp_prior.py) - Mixture of posteriors ([paper](https://arxiv.org/abs/1705.07120))
-- [`UniformCodebookPrior`](src/versatil/models/decoding/latent/prior/uniform_codebook_prior.py) and [`CodebookPrior`](src/versatil/models/decoding/latent/prior/codebook_prior.py) - Fixed or learned priors over VQ codebook indices
-
-Each decoder can customize how it integrates the latent `z` token into its architecture (e.g., prepended token, cross-attention, adaptive normalization).
-
-### Standard Action Decoders
-
-- [`ActionTransformer`](src/versatil/models/decoding/decoders/factory/action_transformer.py) - Bidirectional Transformer Decoder with any configurable positional encoding, normalization, and activation layers.
-- [`ACT`](src/versatil/models/decoding/decoders/factory/act.py) - Action Chunking Transformer ([paper](https://arxiv.org/abs/2304.13705))
-- [`LACT`](src/versatil/models/decoding/decoders/factory/lact.py) - Latent Action Transformer ([paper](https://arxiv.org/abs/2605.22493))
-- [`PhaseACT`](src/versatil/models/decoding/decoders/factory/phase_act.py) - Phase-aware ACT with surgical phase prediction ([paper](https://arxiv.org/abs/2601.21971))
-- [`GPTActionTransformer`](src/versatil/models/decoding/decoders/factory/gpt_action_transformer.py) - Autoregressive GPT-style decoder with tokenized actions
-- [`ConditionalActionUNet`](src/versatil/models/decoding/decoders/factory/conditional_action_unet.py) - U-Net for Diffusion Policy ([paper](https://arxiv.org/abs/2303.04137))
-- [`DiTBlockActionTransformer`](src/versatil/models/decoding/decoders/factory/dit_block_action_transformer.py) - DiT-Block Action Transformer (from [paper](https://arxiv.org/html/2410.10088v1))
-- [`DiffusionActionTransformer`](src/versatil/models/decoding/decoders/factory/diffusion_action_transformer.py) - Diffusion Action Transformer supporting two different architectures:
-    - With cross-attention to encoder tokens, using an architecture inspired by PixArt ([paper](https://arxiv.org/abs/2310.00426))
-    - With a dual-attention stream, using the MultiModal DiT architecture from SD3   ([paper](https://arxiv.org/abs/2403.03206))
-- [`MoDE-ACT`](src/versatil/models/decoding/decoders/factory/mode_act.py) - Mixture Density Network Transformer with K Gaussian expert heads
-- [`MoEDecoder`](src/versatil/models/decoding/decoders/moe.py) - Mixture of Experts wrapper applicable on top of any decoder
-
-### VLA Decoders
-
-These decoders use a vision-language model directly inside the
-action-generation sequence.
-
-- [`AutoregressiveVLADecoder`](src/versatil/models/decoding/decoders/factory/autoregressive_vla.py) - VLM-backed autoregressive action-token decoder used by the `openvla` and `pi0_fast` presets.
-- [`OpenVLAOFTDecoder`](src/versatil/models/decoding/decoders/factory/openvla_oft.py) - VLM-backed continuous action-chunk decoder inspired by [OpenVLA-OFT](https://openvla-oft.github.io/).
-- [`Pi0Decoder`](src/versatil/models/decoding/decoders/factory/pi0.py) - Interleaved VLM-action joint attention ([Pi0](https://arxiv.org/abs/2410.24164), [Pi0.5](https://arxiv.org/abs/2504.16054)). It runs a configured VLM backbone on image/text observations and pairs VLM layers with expert action layers.
-- [`SmolVLADecoder`](src/versatil/models/decoding/decoders/factory/smolvla.py) - Interleaved VLM decoder with alternating joint self-attention and cross-attention over VLM key/value states ([SmolVLA](https://arxiv.org/abs/2506.01844)).
-
-The reusable HF wrappers used by these decoders live in
-`src/versatil/models/decoding/generative_language_models/`. The shipped
-vision-language model identifiers are available at
-`src/versatil/models/decoding/generative_language_models/constants.py`.
-HuggingFace-backed language encoders, VLM encoders, and generative VLM
-backbones accept an optional `lora_config` for PEFT LoRA fine-tuning.
-
-You can easily extend the available decoders by implementing new classes that subclass [`ActionDecoder`](src/versatil/models/decoding/decoders/base.py).
-
----
-
-## Configuration System
-
-**The Composition Pattern:**
-Instead of massive monolithic config files, we mix and match small, reusable blocks, which are located in `src/versatil/hydra_configs/`.
-An end-to-end training config just points to the blocks it wants to use:
-
-```yaml
-# src/versatil/hydra_configs/end_to_end_training_runs/bowel_retraction/act.yaml
-# @package _global_
-_target_: versatil.configs.main.MainConfig
-
-defaults:
-  - /task: base
-  - /policy: base
-  - /experiment: default
-  - /task/dataset_schema: bowel_retraction_v2   # Raw data format
-  - /task/dataloader: bowel_retraction           # Batch size, workers, augmentation
-  - /task/action_space: deltas_cf_pos_gripper_phase
-  - /task/observation_space: stereo_rgb
-  - /training: default
-  - /policy/encoding_pipeline: stereo_rgb        # Encoder + fusion config
-  - /policy/decoder: act_default                 # Action decoder architecture
-  - /policy/algorithm: bc_with_vae_gaussian      # Learning algorithm
-  - /policy/loss: regression_gripper_kl          # Loss composition
-  - _self_
-```
-
-### Config Validation
-
-This is enforced at runtime using OmegaConf's typed Dataclasses.
-The OmegaConf store is defined in `src/versatil/configs/__init__.py`.
-Whenever you create a new config file, define a matching Dataclass in `src/versatil/configs/` to enforce types and defaults, and register it in the store.
-This prevents silent errors from typos, wrong or missing parameters.
-
-### Interpolation
-
-You can reference other config values using `${}`:
-
-```yaml
-policy:
-  prediction_horizon: ${task.prediction_horizon}
-  observation_space: ${task.observation_space}
-  device: ${experiment.device}
-```
-You can also define custom interpolation resolvers in `src/versatil/configs/__init__.py`, to interpolate e.g. Enum.values.
-
----
-
-## 📊 Monitoring & Logging
-
-### WandB Integration
-
-Set environment variable:
-```bash
-export WANDB_API_KEY=your_key_here
-```
-Or add it to your `.bashrc` profile, for persistent settings.
-
-
-### Checkpointing
-
-**Best models** (based on `val_loss`):
-```
-checkpoints/experiment_name/best-epoch=XX-val_loss=Y.YYYY.ckpt
-```
-
-**Latest checkpoints** (every N epochs):
-```
-checkpoints/experiment_name/latest-epoch=XX.ckpt
-checkpoints/experiment_name/last.ckpt
-```
-
-**Resume training:**
-```bash
-python -m versatil.endpoints.train \
-    --config-name end_to_end_training_runs/bowel_retraction/act \
-    experiment.resume_from=/path/to/checkpoint.ckpt
-```
-
----
-
-## 🧪 Testing
-
-```bash
-# Run the default local suite: excludes slow, integration, and GPU-only tests
+# Default local suite: excludes slow, integration, GPU-only, and ExecuTorch-dependent tests
 pytest
 
-# Run all tests including integration tests
-pytest -m ""
-
-# Run specific test file
-pytest tests/models/test_policy.py
-
-# Run tests by marker
-pytest -m "unit"                                      # Fast tests with mocked dependencies
-pytest -m "integration"                               # Real component integration tests
-pytest -m "requires_gpu"                              # GPU-required tests
-pytest -m "not slow and not integration and not requires_gpu"  # Explicit default selection
+# Format and lint (pre-commit hooks run this on every commit)
+ruff format src/ tests/ && ruff check src/ tests/
 ```
 
----
-
-## 📝 Code Style
-
-- **Docstrings**: Google-style, concise (avoid LLM patterns like numbered lists or excessive words)
-- **Type hints**: Required for all function signatures
-- **Formatter/Linter**: [Ruff](https://docs.astral.sh/ruff/) (line length 88, lint target pinned to `py313` so annotation imports stay at runtime for OmegaConf)
-- **No inline imports**: All imports at module top
-- **Minimal comments**: Only for tensor shapes or non-obvious logic
-- **Variables**: Use English words, avoid abbreviations
-- **Function calls**: Use kwargs
-- **Error handling**: Use `raise`, avoid assertions and try/catch blocks
-- **Strings**: Use double quotes (`"foo"` not `'foo'`)
-- **Constants**: Avoid hardcoded strings, use `Enum.MY_ENUM.value`
-- **No wildcard imports**: Avoid `from module import *`
-- Avoid `**kwargs` and `*args` signatures: Explicit is better than implicit
-
-```bash
-# Format code
-ruff format src/ tests/
-
-# Check formatting
-ruff format --check src/ tests/
-
-# Lint
-ruff check src/ tests/
-
-# Lint and auto-fix
-ruff check --fix src/ tests/
-```
-
-Pre-commit hooks run ruff automatically on every `git commit`.
+Development setup, testing conventions, code style rules, and PR guidelines are in [CONTRIBUTING.md](https://github.com/Lorenzo-Mazza/VersatIL/blob/main/CONTRIBUTING.md).
 
 ---
 
 ## 🐛 Troubleshooting
 
-### CUDA Issues
-- Verify the NVIDIA driver supports CUDA 13.0 with `nvidia-smi`
-- Check `torch.cuda.is_available()` returns `True`
+Common issues (CUDA, data loading, Python 3.14 quirks) are collected in the [training guide](https://lorenzo-mazza.github.io/VersatIL/getting-started/training/#troubleshooting) and the [Known Issues](https://lorenzo-mazza.github.io/VersatIL/known-issues/) page.
 
-### Data Loading
-- Verify Zarr dataset paths and permissions
-- Check dataset schema matches your data
-- Ensure sufficient disk space for Zarr cache
+---
 
-### Python Compatibility
-If torchao crashes on Python 3.14, see the [Known Issues](https://lorenzo-mazza.github.io/VersatIL/known-issues/) docs for active workarounds.
+## 📖 Citation
+
+If you use VersatIL in your research, please cite the repository:
+
+```bibtex
+@misc{mazza2026versatil,
+    author = {Mazza, Lorenzo and Rodriguez, Ariel and Speidel, Stefanie},
+    title = {VersatIL: A Modular Imitation Learning Framework for Robot Policies},
+    howpublished = {\url{https://github.com/Lorenzo-Mazza/VersatIL}},
+    year = {2026}
+}
+```
+
+If you use the MoE-ACT policy, please also cite:
+
+```bibtex
+@article{mazza2026moe,
+  title={MoE-ACT: Improving Surgical Imitation Learning Policies through Supervised Mixture-of-Experts},
+  author={Mazza, Lorenzo and Rodriguez, Ariel and Younis, Rayan and Lelis, Martin and Hellig, Ortrun and Li, Chenpan and Bodenstedt, Sebastian and Wagner, Martin and Speidel, Stefanie},
+  journal={arXiv preprint arXiv:2601.21971},
+  year={2026}
+}
+```
+
+If you use the LACT policy, please also cite:
+
+```bibtex
+@article{mazza2026understanding,
+  title={Understanding Multimodal Failure in Action-Chunking Behavioral Cloning},
+  author={Mazza, Lorenzo and Datres, Massimiliano and Rodriguez, Ariel and Bodenstedt, Sebastian and Kutyniok, Gitta and Speidel, Stefanie},
+  journal={arXiv preprint arXiv:2605.22493},
+  year={2026}
+}
+```
+
+---
+
+## 📄 License
+
+VersatIL is released under the [MIT License](LICENSE).
+
+---
+
+## 🙌 Contributors
+
+Thanks to all [contributors](https://github.com/Lorenzo-Mazza/VersatIL/blob/main/contributors.md) who make VersatIL possible! Want to join them? Start with the [contributing guide](https://github.com/Lorenzo-Mazza/VersatIL/blob/main/CONTRIBUTING.md).

--- a/docs/architecture/algorithms.md
+++ b/docs/architecture/algorithms.md
@@ -113,7 +113,7 @@ Generative modeling via Denoising Score Matching. Trains the network to denoise 
 
 ## [`FlowMatching`][versatil.models.decoding.algorithm.flow_matching.FlowMatching]
 
-Generative modeling via Continuous Normalizing Flows. Trains the network to predict velocity fields that transport samples from noise to actions.
+Simulation-free generative modeling via conditional flow matching. Trains the network to regress velocity fields that transport samples from noise to actions, then integrates the learned field as an ODE at inference.
 
 **Training (`forward`):**
 

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -43,16 +43,16 @@ Ready-to-use end-to-end configs exist under `src/versatil/hydra_configs/end_to_e
 
 | Dataset                                                                  | Config Path | Data Link | Notes                                                            |
 |--------------------------------------------------------------------------|---|---|------------------------------------------------------------------|
-| [Bowel Retraction](https://arxiv.org/abs/2601.21971) | `bowel_retraction/` | Coming soon | Real-world UR5e surgical robotics demonstrations (stereo RGB, depth, language, phase labels). |
+| [Bowel Retraction](https://arxiv.org/abs/2601.21971) | `bowel_retraction/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_bowel_grasping) | Real-world UR5e surgical robotics demonstrations (stereo RGB, depth, language, phase labels). |
 | [LIBERO Original](https://libero-project.github.io/datasets) (HDF5)      | `libero_hdf5/` | [libero-project.github.io](https://libero-project.github.io/datasets) | Original HDF5 format, 128x128 images.                            |
 | [LIBERO](https://huggingface.co/datasets/lerobot/libero) (LeRobot)       | `libero_lerobot/` | [HF Hub](https://huggingface.co/datasets/lerobot/libero) | LeRobot format, OpenVLA filtered demonstrations, 256x256 images. |
 | [LIBERO+](https://huggingface.co/datasets/Sylvest/libero_plus_lerobot)   | `libero_plus/` | [HF Hub](https://huggingface.co/datasets/Sylvest/libero_plus_lerobot) | Extended LIBERO dataset.                                         |
 | [MetaWorld MT50](https://huggingface.co/datasets/lerobot/metaworld_mt50) | `metaworld/` | [HF Hub](https://huggingface.co/datasets/lerobot/metaworld_mt50) | Multi-task benchmark (MT50 variant).                             |
-| PushT                                                                    | `pusht/` | Local/LeRobot-compatible data | 2D pushing benchmark configs.                                    |
-| Block Pushing                                                            | `block_pushing/` | Local/LeRobot-compatible data | Relative and absolute action-space variants.                     |
-| Kitchen                                                                  | `kitchen/` | Local/LeRobot-compatible data | Q-FAT relay kitchen configs.                                     |
-| Multimodal Ant                                                           | `ant/` | Local/LeRobot-compatible data | State-only multimodal ant benchmark configs.                     |
-| UR3 Block Push                                                           | `ur3/` | Local/LeRobot-compatible data | State-only UR3 block-push benchmark configs.                     |
+| PushT                                                                    | `pusht/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_pusht_lerobot) | 2D pushing benchmark configs.                                    |
+| Block Pushing                                                            | `block_pushing/` | [relative](https://huggingface.co/datasets/nct-tso/robotics_blockpush_relative_lerobot), [absolute](https://huggingface.co/datasets/nct-tso/robotics_blockpush_absolute_lerobot) | Relative and absolute action-space variants.                     |
+| Kitchen                                                                  | `kitchen/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_kitchen_lerobot) | Relay kitchen (Franka Kitchen) configs.                          |
+| Multimodal Ant                                                           | `ant/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_multimodal_ant_lerobot) | State-only multimodal ant benchmark configs.                     |
+| UR3 Block Push                                                           | `ur3/` | [HF Hub](https://huggingface.co/datasets/nct-tso/robotics_ur3_blockpush_lerobot) | State-only UR3 block-push benchmark configs.                     |
 | Synthetic                                                                | `synthetic/` | Generated on demand | Lightweight synthetic multimodal benchmark configs.              |
 
 ### Zarr Store Creation

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -46,7 +46,7 @@ VersatIL decouples the learning paradigm from the neural network structure. The 
 
 - [`BehavioralCloning`][versatil.models.decoding.algorithm.behavior_cloning.BehavioralCloning] -- direct supervised learning of expert actions
 - [`Diffusion`][versatil.models.decoding.algorithm.diffusion.Diffusion] -- iterative denoising via Denoising Score Matching
-- [`FlowMatching`][versatil.models.decoding.algorithm.flow_matching.FlowMatching] -- continuous normalizing flows
+- [`FlowMatching`][versatil.models.decoding.algorithm.flow_matching.FlowMatching] -- velocity-field regression along noise-to-action paths
 - [`VariationalAlgorithm`][versatil.models.decoding.algorithm.variational.VariationalAlgorithm] -- wraps any base algorithm with VAE-style latent variables
 
 **[`ActionDecoder`][versatil.models.decoding.decoders.base.ActionDecoder]** defines *what* neural network processes features:

--- a/docs/architecture/post_training_compression.md
+++ b/docs/architecture/post_training_compression.md
@@ -1,7 +1,9 @@
 # Post-Training Compression
 
-VersatIL's post-training compression (PTC) pipeline turns a trained policy
-checkpoint into a deployment artifact. It owns the end-to-end compression job:
+**What is post-training compression?**
+The post-training compression (PTC) pipeline turns a trained policy checkpoint into a deployment artifact for edge or resource-constrained hardware. A PTC run can export a floating-point model, apply pruning, quantize the policy, and save either a Torch Export `.pt2` artifact or an ExecuTorch `.pte` artifact.
+
+The pipeline owns the end-to-end compression job:
 checkpoint loading, optional model preparation, pruning, quantization workflow
 execution, deployment backend export, serialization, and reporting.
 
@@ -153,6 +155,13 @@ compressed/<timestamp>/
 `CompressedCheckpointLoader` reads the metadata, normalizer, tokenizer, and
 artifact. `CompressedPolicyRuntime` then exposes the same runtime interface used
 by the inference client for floating-point policies.
+
+!!! warning "Compressed artifacts are not standalone"
+
+    Currently, compressed models are not fully standalone: they still require
+    a complete VersatIL installation, including its dependencies. Since this
+    is not ideal for edge deployment, self-contained edge-device inference
+    runtime is currently under development.
 
 ## Hydra Configuration
 

--- a/docs/architecture/quantization.md
+++ b/docs/architecture/quantization.md
@@ -1,5 +1,15 @@
 # Quantization
 
+## Background
+
+**What is post-training quantization?**
+Post-training quantization (PTQ) converts trained floating-point model weights and activations to lower-precision integer representations (e.g., INT8). This reduces memory footprint, improves cache utilization, and enables hardware-accelerated integer arithmetic — typically achieving inference speedup on x86 CPUs with minimal accuracy loss. PTQ is done after training. Static quantization uses a small calibration dataset to determine optimal activation ranges per layer; dynamic quantization computes ranges on-the-fly at inference time and needs no calibration.
+
+**What is quantization-aware-training?**
+Quantization-aware training inserts fake quantizers between layers of the neural policy to mimic the information loss that the policy will experience at deployment time after PTQ. In this way, the policy learns a mapping that is robust to PTQ-induced information loss, improving downstream performance.
+
+## Workflows
+
 VersatIL implements quantization workflows built on the popular
 [`torchao`](https://docs.pytorch.org/ao/main/) library from PyTorch. The
 workflow owns the order of operations needed to load a checkpoint, optionally

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -123,8 +123,43 @@ uv sync --python "$PYTHON_VERSION" --extra cpu --extra executorch
 
 The `executorch` extra is ignored on Python 3.14 by package markers because the
 published ExecuTorch wheel currently declares `requires-python = ">=3.10,<3.14"`.
-Use the source-build flow from the README when ExecuTorch is needed in a Python
-3.14 environment.
+Python 3.14 environments need an ExecuTorch package built from source in the
+active `versatil` environment:
+
+```bash
+cd ..
+git clone https://github.com/pytorch/executorch.git
+cd executorch
+git submodule update --init --recursive
+
+# Build dependencies must be present because --no-build-isolation is used.
+pip install "cmake>=3.24,<4.0.0" "packaging>=24.2" pyyaml "setuptools>=77.0.3" wheel zstd certifi ninja
+
+SITE_PACKAGES=$(python - <<'PY'
+import site
+print(site.getsitepackages()[0])
+PY
+)
+# CUDA and OpenVINO must be disabled explicitly
+# because setup.py auto-enables them when nvcc / Linux are detected; the LLM
+# kernels are preset defaults this deployment does not need.
+CMAKE_PREFIX_PATH="$SITE_PACKAGES" \
+CMAKE_BUILD_PARALLEL_LEVEL=8 \
+CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=OFF -DEXECUTORCH_BUILD_OPENVINO=OFF -DEXECUTORCH_BUILD_KERNELS_LLM=OFF -DEXECUTORCH_BUILD_KERNELS_LLM_AOT=OFF" \
+python -m pip install . --no-build-isolation --ignore-requires-python --no-deps -v
+
+cd ../versatil
+
+# Runtime dependencies are skipped by --no-deps; install the AoT set manually.
+pip install flatbuffers "ruamel.yaml" sympy tabulate pytorch-tokenizers \
+    expecttest hypothesis kgb parameterized
+
+# Now all ExecuTorch-gated tests should pass.
+pytest -m requires_executorch -o addopts=""
+```
+
+`python -m pip check` can still report a `scikit-learn` metadata conflict in
+Python 3.14 environments. The XNNPACK export path works with the built package.
 
 ### Install Pre-commit Hooks
 
@@ -189,7 +224,7 @@ WANDB_ENTITY=your-team
 ## Verifying the Installation
 
 Activate the environment and run the default local test selection. This excludes
-slow, integration, and GPU-only tests via `pyproject.toml`:
+slow, integration, GPU-only, and ExecuTorch-dependent tests via `pyproject.toml`:
 
 ```bash
 mamba activate versatil

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ _Imitation Learning for Any Robot Policy._
 
 ---
 
-VersatIL is a composable PyTorch framework for training robot policies through Imitation Learning. It decouples **Data**, **Algorithm**, and **Architecture** so you can build, benchmark, and deploy any policy from config alone.
+VersatIL is a composable PyTorch framework for training robot policies through Imitation Learning. It decouples **Data**, **Algorithm**, **Architecture**, and **Loss** so you can build, benchmark, and deploy any policy from config alone.
 
 The key features are:
 
@@ -120,6 +120,14 @@ The key features are:
     Transport protocols, preprocessing, temporal aggregation.
 
     [:octicons-arrow-right-24: Inference](architecture/inference.md)
+
+-   **Explainability**
+
+    ---
+
+    Grad-CAM, Grad-CAM++, and Ablation-CAM heatmaps for any trained policy.
+
+    [:octicons-arrow-right-24: Explainability](architecture/explainability.md)
 
 -   **Quantization**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "VersatIL"
-version = "0.4.0"
+version = "0.4.1"
 description = "Modular imitation learning framework for training, compressing, and deploying robot manipulation policies"
 readme = "README.md"
 authors = [

--- a/src/versatil/data/synthetic/assets/RobotoSerif-OFL.txt
+++ b/src/versatil/data/synthetic/assets/RobotoSerif-OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2013 The Roboto Serif Project Authors (https://github.com/googlefonts/roboto-serif)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/src/versatil/models/decoding/algorithm/flow_matching.py
+++ b/src/versatil/models/decoding/algorithm/flow_matching.py
@@ -1,4 +1,4 @@
-"""Flow Matching algorithm for action generation via continuous normalizing flows."""
+"""Flow Matching algorithm for action generation via learned velocity fields."""
 
 import torch
 

--- a/uv.lock
+++ b/uv.lock
@@ -3801,7 +3801,7 @@ wheels = [
 
 [[package]]
 name = "versatil"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Prepares the v0.4.1 patch release:

- README rewritten as a showcase; deep-dive material moved into the docs and CONTRIBUTING.md
- Flow matching description and paper reference corrected across README, docs, and docstring
- Bundled Roboto Serif font now ships with its SIL OFL license text (0.4.1 wheel fix)
- CITATION.cff added; PyPI logo rendering fixed
- Docs refresh: published dataset links, quantization/PTC background, ExecuTorch build flow in the installation guide
- Version bumped to 0.4.1

After merge, tag `v0.4.1` triggers the PyPI publish workflow.