### PR TITLE
Fix uv install instructions: pre-release flag required

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ VersatIL requires Python 3.13 or 3.14 and is available on PyPI:
 # With uv
 uv venv --python 3.14
 source .venv/bin/activate
-uv pip install versatil
+uv pip install versatil --prerelease=allow
 
 # Or with mamba/conda
 mamba create -n versatil python=3.14 pip

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,13 +19,18 @@ the package:
 # With uv
 uv venv --python 3.14
 source .venv/bin/activate
-uv pip install versatil
+uv pip install versatil --prerelease=allow
 
 # Or with mamba/conda
 mamba create -n versatil python=3.14 pip
 mamba activate versatil
 pip install versatil
 ```
+
+The `--prerelease=allow` flag is required with uv: Python 3.13/3.14 support
+in `hydra-core` and `omegaconf` is currently published as pre-releases, which
+plain `pip` accepts automatically but uv rejects for transitive dependencies,
+silently resolving an old versatil version instead.
 
 The default PyPI PyTorch wheel runs on both CPU-only and CUDA machines. The
 dedicated CPU-only or CUDA 13.0 wheel sets are selected through the


### PR DESCRIPTION
Found during the post-release smoke test: in a clean environment, `uv pip install versatil` silently resolves **versatil 0.3.0** because uv rejects the pre-release floor `hydra-core>=1.4.0.dev5` on transitive dependencies and backtracks to the last version without it. Plain `pip` resolves 0.4.1 correctly.

- Added `--prerelease=allow` to the uv install lines in the README and installation guide, with a short explanation.
- Verified in a clean venv: with the flag uv resolves 0.4.1; pip needs no change.
- Also verified end-to-end from the clean PyPI install: 1-epoch synthetic BCAT training runs to completion on CPU.