### PR TITLE
Keep trainable parameters in float32 under mixed precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Mixed-precision training keeps trainable parameters in float32 storage, so optimizer updates no longer round away in bf16. This unblocks autoregressive OpenVLA LoRA fine-tuning, whose adapters previously never left their initialization.
+- Forward passes outside the Lightning loop (synthetic rollout evaluation, prior target standardization, explainability attribution, encoder shape probing) run under the same autocast as training instead of crashing on mixed-precision policies.
+
+### Changed
+- OpenVLA and OpenVLA-OFT presets train LoRA with the recipe learning rate of 5e-4.
+
 ## [0.4.1] - 2026-07-05
 
 ### Fixed

--- a/src/versatil/explainability/runner.py
+++ b/src/versatil/explainability/runner.py
@@ -29,7 +29,7 @@ from versatil.inference.socket_transport import (
     SocketObservationTransport,
 )
 from versatil.models.policy import Policy
-from versatil.training.constants import CheckpointFilename
+from versatil.training.constants import CheckpointFilename, PrecisionType
 
 DEFAULT_ONLINE_MAX_STEPS = 1_000_000
 
@@ -436,16 +436,18 @@ class ExplainabilityRunner:
         heatmap_function = self.explanation_heatmaps[explanation_type]
         heatmaps: dict[str, torch.Tensor] = {}
         target_cameras = self._get_target_cameras()
-        for target_camera in target_cameras:
-            current_heatmaps = heatmap_function(
-                policy=self.policy,
-                observation=observation,
-                actions=actions,
-                target_camera=target_camera,
-                target_vision_module_names=self.target_vision_module_names,
-                preprocess_observation=preprocess_observation,
-            )
-            heatmaps.update(current_heatmaps)
+        precision_type = PrecisionType(str(self.config.experiment.precision))
+        with precision_type.autocast(device_type=self.device.type):
+            for target_camera in target_cameras:
+                current_heatmaps = heatmap_function(
+                    policy=self.policy,
+                    observation=observation,
+                    actions=actions,
+                    target_camera=target_camera,
+                    target_vision_module_names=self.target_vision_module_names,
+                    preprocess_observation=preprocess_observation,
+                )
+                heatmaps.update(current_heatmaps)
         return heatmaps
 
     def _get_target_cameras(self) -> list[str | None]:

--- a/src/versatil/explainability/writer.py
+++ b/src/versatil/explainability/writer.py
@@ -68,7 +68,7 @@ class ExplanationWriter:
             {
                 "metadata": metadata,
                 "heatmaps": {
-                    camera: heatmap.detach().cpu()
+                    camera: heatmap.detach().float().cpu()
                     for camera, heatmap in heatmaps.items()
                 },
             },
@@ -103,7 +103,7 @@ class ExplanationWriter:
                 raise RuntimeError(
                     f"No display observation found for heatmap camera '{camera}'."
                 )
-            cpu_heatmap = heatmap.detach().cpu()
+            cpu_heatmap = heatmap.detach().float().cpu()
             for batch_index in range(cpu_heatmap.shape[0]):
                 sample_label = self.sample_label(
                     metadata=batch.metadata,

--- a/src/versatil/hydra_configs/end_to_end_training_runs/libero_lerobot/openvla.yaml
+++ b/src/versatil/hydra_configs/end_to_end_training_runs/libero_lerobot/openvla.yaml
@@ -62,7 +62,7 @@ training:
   lr_scheduler_kwargs:
     min_lr: 2.5e-6
   optimizer:
-    lr: 2.5e-5
+    lr: 5e-4
     betas: [0.9, 0.95]
     weight_decay: 0.01
     param_groups: []

--- a/src/versatil/hydra_configs/end_to_end_training_runs/libero_lerobot/openvla_oft.yaml
+++ b/src/versatil/hydra_configs/end_to_end_training_runs/libero_lerobot/openvla_oft.yaml
@@ -49,7 +49,7 @@ training:
   lr_scheduler_kwargs:
     min_lr: 2.5e-6
   optimizer:
-    lr: 2.5e-5
+    lr: 5e-4
     betas: [0.9, 0.95]
     weight_decay: 0.01
     param_groups: []

--- a/src/versatil/models/decoding/generative_language_models/base.py
+++ b/src/versatil/models/decoding/generative_language_models/base.py
@@ -49,10 +49,10 @@ class GenerativeLanguageModel(ModuleAttrMixin, abc.ABC):
                     f"Invalid model_dtype '{model_dtype}'. "
                     f"Must be one of: {valid_values}"
                 )
-            self.model_dtype: torch.dtype | None = PrecisionType(
-                model_dtype
-            ).get_model_dtype()
+            self.precision_type: PrecisionType | None = PrecisionType(model_dtype)
+            self.model_dtype: torch.dtype | None = self.precision_type.get_model_dtype()
         else:
+            self.precision_type = None
             self.model_dtype = None
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -78,11 +78,25 @@ class GenerativeLanguageModel(ModuleAttrMixin, abc.ABC):
         return self
 
     def _apply_model_dtype(self) -> None:
-        """Cast the module tree to the configured model dtype."""
+        """Cast the module tree to the configured model dtype.
+
+        Note:
+            Under mixed precision, trainable parameters are
+            kept in float32 storage: autocast already runs the compute in the low
+            precision, while float32 masters prevent optimizer updates smaller
+            than the parameter's low-precision rounding step from vanishing.
+
+            The method must be called after ``requires_grad`` flags are final
+            (freezing, LoRA wrapping).
+        """
         target_dtype = (
             self.model_dtype if self.model_dtype is not None else torch.float32
         )
         self.to(target_dtype)
+        if self.precision_type is not None and self.precision_type.is_mixed():
+            for parameter in self.parameters():
+                if parameter.requires_grad:
+                    parameter.data = parameter.data.float()
 
     def get_vocab_size(self) -> int | None:
         """Get vocabulary size if applicable, else None."""

--- a/src/versatil/models/encoding/encoders/base.py
+++ b/src/versatil/models/encoding/encoders/base.py
@@ -48,10 +48,10 @@ class EncodingMixin(ModuleAttrMixin, abc.ABC):
                     f"Invalid model_dtype '{model_dtype}'. "
                     f"Must be one of: {valid_values}"
                 )
-            self.model_dtype: torch.dtype | None = PrecisionType(
-                model_dtype
-            ).get_model_dtype()
+            self.precision_type: PrecisionType | None = PrecisionType(model_dtype)
+            self.model_dtype: torch.dtype | None = self.precision_type.get_model_dtype()
         else:
+            self.precision_type = None
             self.model_dtype = None
         if device is None:
             device = "cuda" if _cuda_runtime_available() else "cpu"
@@ -77,19 +77,53 @@ class EncodingMixin(ModuleAttrMixin, abc.ABC):
         return self
 
     def _apply_model_dtype(self) -> None:
-        """Cast the entire encoder module tree to a consistent dtype.
+        """Cast the entire encoder module tree to the configured model dtype.
 
-        When ``model_dtype`` is set explicitly, casts to that dtype.
-        When ``model_dtype`` is None, casts to ``torch.float32``.
+        Note:
+            When ``model_dtype`` is set explicitly, casts to that dtype; when it is
+            None, casts to ``torch.float32``.
 
-        Called by child encoders at the end of ``__init__`` and after any
-        deferred-build method (``set_image_size``, ``_build_network``, …) so
-        a rebuild cannot leak mismatched-dtype submodules back into the tree.
+            Called by child encoders at the end of ``__init__`` and after any
+            deferred-build method (``set_image_size``, ``_build_network``, …) so
+            a rebuild cannot leak mismatched-dtype submodules back into the tree.
+            Must run after ``requires_grad`` flags are final (freezing, LoRA
+            wrapping).
         """
         target_dtype = (
             self.model_dtype if self.model_dtype is not None else torch.float32
         )
         self.to(target_dtype)
+        if self.precision_type is not None and self.precision_type.is_mixed():
+            for parameter in self.parameters():
+                if parameter.requires_grad:
+                    parameter.data = parameter.data.float()
+
+    def _mock_forward_dtype(self) -> torch.dtype:
+        """Return the input dtype for mock forward passes.
+
+        Mock forward passes push a zero-filled input through the encoder at
+        setup time, only to measure output feature shapes. Mixed precisions
+        run the mock input in float32 inside ``_mock_forward_autocast()``,
+        mirroring training-time autocast over the encoder's mixed float32/
+        low-precision parameters. Other precisions run the mock input
+        directly in the parameter dtype.
+        """
+        if self.precision_type is not None and self.precision_type.is_mixed():
+            return torch.float32
+        return self.model_dtype if self.model_dtype is not None else torch.float32
+
+    def _mock_forward_autocast(self) -> torch.autocast:
+        """Return the autocast context for mock forward passes."""
+        mixed = self.precision_type is not None and self.precision_type.is_mixed()
+        first_parameter = next(self.parameters(), None)
+        device_type = (
+            first_parameter.device.type if first_parameter is not None else "cpu"
+        )
+        return torch.autocast(
+            device_type=device_type,
+            dtype=self.model_dtype if mixed else None,
+            enabled=mixed,
+        )
 
     @abstractmethod
     def get_output_specification(self) -> list[FeatureMetadata]:

--- a/src/versatil/models/encoding/encoders/cross_modal/rgbd/dformerv2.py
+++ b/src/versatil/models/encoding/encoders/cross_modal/rgbd/dformerv2.py
@@ -531,17 +531,21 @@ class DFormerEncoder(RGBDEncoderMixin, Encoder):
             image_height: Target image height.
             image_width: Target image width.
         """
-        probe_dtype = (
-            self.model_dtype if self.model_dtype is not None else torch.float32
-        )
-        with torch.no_grad():
-            mock_rgb = torch.zeros(1, 3, image_height, image_width, dtype=probe_dtype)
+        mock_input_dtype = self._mock_forward_dtype()
+        with torch.no_grad(), self._mock_forward_autocast():
+            mock_rgb = torch.zeros(
+                1, 3, image_height, image_width, dtype=mock_input_dtype
+            )
             features = self.patch_embed(mock_rgb)
-            depth_map = torch.zeros(1, 1, image_height, image_width, dtype=probe_dtype)
+            depth_map = torch.zeros(
+                1, 1, image_height, image_width, dtype=mock_input_dtype
+            )
             for stage in self.stages:
                 _, features, depth_map = stage(features, depth_map)
             _, spatial_height, spatial_width, _ = features.shape
         self._setup_pooling(spatial_height=spatial_height, spatial_width=spatial_width)
+        if self.frozen:
+            self._freeze_weights()
         self._apply_model_dtype()
 
     def get_explainability_targets(self) -> list[VisionExplanationTarget]:

--- a/src/versatil/models/encoding/encoders/cross_modal/rgbd/geometric_rgbd.py
+++ b/src/versatil/models/encoding/encoders/cross_modal/rgbd/geometric_rgbd.py
@@ -201,12 +201,14 @@ class GeometricRGBDEncoder(RGBDEncoderMixin, Encoder):
             image_height: Target image height.
             image_width: Target image width.
         """
-        probe_dtype = (
-            self.model_dtype if self.model_dtype is not None else torch.float32
-        )
-        with torch.no_grad():
-            mock_rgb = torch.zeros(1, 3, image_height, image_width, dtype=probe_dtype)
-            mock_depth = torch.zeros(1, 1, image_height, image_width, dtype=probe_dtype)
+        mock_input_dtype = self._mock_forward_dtype()
+        with torch.no_grad(), self._mock_forward_autocast():
+            mock_rgb = torch.zeros(
+                1, 3, image_height, image_width, dtype=mock_input_dtype
+            )
+            mock_depth = torch.zeros(
+                1, 1, image_height, image_width, dtype=mock_input_dtype
+            )
             _, spatial_height, spatial_width = self.encode_features(
                 rgb_image=mock_rgb, depth_map=mock_depth
             )

--- a/src/versatil/models/encoding/encoders/rgb/conditional_cnn.py
+++ b/src/versatil/models/encoding/encoders/rgb/conditional_cnn.py
@@ -406,13 +406,13 @@ class ConditionalCNNEncoder(RGBEncoderMixin, ConditionalEncoder):
             image_height: Target image height.
             image_width: Target image width.
         """
-        probe_dtype = (
-            self.model_dtype if self.model_dtype is not None else torch.float32
-        )
-        with torch.no_grad():
-            mock_input = torch.zeros(1, 3, image_height, image_width, dtype=probe_dtype)
+        mock_input_dtype = self._mock_forward_dtype()
+        with torch.no_grad(), self._mock_forward_autocast():
+            mock_input = torch.zeros(
+                1, 3, image_height, image_width, dtype=mock_input_dtype
+            )
             mock_condition = torch.zeros(
-                1, self.conditioning_dimension, dtype=probe_dtype
+                1, self.conditioning_dimension, dtype=mock_input_dtype
             )
             features = self.backbone(mock_input, mock_condition)
             _, _, spatial_height, spatial_width = features.shape

--- a/src/versatil/models/encoding/encoders/spatial_backbone.py
+++ b/src/versatil/models/encoding/encoders/spatial_backbone.py
@@ -250,16 +250,18 @@ class SpatialBackboneEncoder(ImageEncoderMixin, Encoder):
             self.feature_dim = self._get_intermediate_layer_channels()
             if self.frozen:
                 self._freeze_weights()
-            # The rebuilt backbone is float32; recast before the probe below
-            # runs a model_dtype input through it.
+            # The rebuilt backbone is float32; recast before the mock
+            # forward below runs an input through it.
             self._apply_model_dtype()
 
-        probe_dtype = (
-            self.model_dtype if self.model_dtype is not None else torch.float32
-        )
-        with torch.no_grad():
+        mock_input_dtype = self._mock_forward_dtype()
+        with torch.no_grad(), self._mock_forward_autocast():
             mock_input = torch.zeros(
-                1, self._input_channels, image_height, image_width, dtype=probe_dtype
+                1,
+                self._input_channels,
+                image_height,
+                image_width,
+                dtype=mock_input_dtype,
             )
             intermediate_outputs = self.backbone(mock_input)
             layer_index = self._resolve_intermediate_layer_index(

--- a/src/versatil/training/callbacks/prior_target_standardization.py
+++ b/src/versatil/training/callbacks/prior_target_standardization.py
@@ -11,6 +11,7 @@ from versatil.common.tensor_ops import to_device
 from versatil.data.constants import SampleKey
 from versatil.models.decoding.latent.prior.latent_standardizer import LatentStandardizer
 from versatil.models.policy import Policy
+from versatil.training.constants import PrecisionType
 from versatil.training.lightning_policy import LightningPolicy
 
 
@@ -51,8 +52,7 @@ class PriorTargetStandardizationCallback(Callback):
             trainer: Active Lightning trainer.
             pl_module: Lightning module wrapping the policy.
         """
-        del trainer
-        self._fit_if_ready(pl_module=pl_module)
+        self._fit_if_ready(trainer=trainer, pl_module=pl_module)
 
     def on_train_epoch_start(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
@@ -63,8 +63,7 @@ class PriorTargetStandardizationCallback(Callback):
             trainer: Active Lightning trainer.
             pl_module: Lightning module wrapping the policy.
         """
-        del trainer
-        self._fit_if_ready(pl_module=pl_module)
+        self._fit_if_ready(trainer=trainer, pl_module=pl_module)
 
     @staticmethod
     def _require_lightning_policy(pl_module: pl.LightningModule) -> LightningPolicy:
@@ -86,10 +85,11 @@ class PriorTargetStandardizationCallback(Callback):
             )
         return pl_module
 
-    def _fit_if_ready(self, pl_module: pl.LightningModule) -> None:
+    def _fit_if_ready(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Fit standardizer stats if runtime state satisfies the fit contract.
 
         Args:
+            trainer: Active Lightning trainer providing the training precision.
             pl_module: Lightning module wrapping the policy.
 
         Raises:
@@ -124,6 +124,7 @@ class PriorTargetStandardizationCallback(Callback):
                 standardizer=standardizer,
                 train_dataloader=train_dataloader,
                 device=lightning_policy.device,
+                precision_type=PrecisionType(str(trainer.precision)),
             )
         finally:
             self._restore_training_modes(training_modes)
@@ -206,6 +207,7 @@ class PriorTargetStandardizationCallback(Callback):
         standardizer: torch.nn.Module,
         train_dataloader: Iterable,
         device: torch.device,
+        precision_type: PrecisionType,
     ) -> tuple[torch.Tensor, torch.Tensor, int]:
         """Stream posterior targets and compute latent mean/std.
 
@@ -215,6 +217,9 @@ class PriorTargetStandardizationCallback(Callback):
             standardizer: Latent standardizer receiving the fitted stats.
             train_dataloader: Dataloader yielding policy training batches.
             device: Device used for the stats pass.
+            precision_type: Trainer precision; mixed precisions run the stats
+                pass under the same autocast as training so the fitted stats
+                match the latents the prior sees.
 
         Returns:
             Tuple of mean, standard deviation, and number of observed targets.
@@ -227,7 +232,7 @@ class PriorTargetStandardizationCallback(Callback):
         sum_squared_latents = torch.zeros_like(sum_latents)
         count = torch.zeros((), device=device, dtype=torch.float64)
 
-        with torch.no_grad():
+        with torch.no_grad(), precision_type.autocast(device_type=device.type):
             for batch_index, batch in enumerate(train_dataloader):
                 if self.max_batches is not None and batch_index >= self.max_batches:
                     break

--- a/src/versatil/training/callbacks/synthetic_rollout.py
+++ b/src/versatil/training/callbacks/synthetic_rollout.py
@@ -16,6 +16,7 @@ from versatil.data.synthetic.visualization import plot_trajectories_2d
 from versatil.inference.synthetic_rollout import evaluate_rollouts, run_rollouts
 from versatil.models.policy import Policy
 from versatil.training.callbacks.wandb_figure import figure_to_wandb_image
+from versatil.training.constants import PrecisionType
 
 
 class SyntheticRolloutCallback(Callback):
@@ -80,7 +81,11 @@ class SyntheticRolloutCallback(Callback):
         policy.eval()
 
         context_modes = self._resolve_context_modes(policy=policy)
-        with torch.no_grad():
+        precision_type = PrecisionType(str(trainer.precision))
+        with (
+            torch.no_grad(),
+            precision_type.autocast(device_type=pl_module.device.type),
+        ):
             per_mode_trajectories = [
                 run_rollouts(
                     policy=policy,

--- a/src/versatil/training/constants.py
+++ b/src/versatil/training/constants.py
@@ -50,6 +50,37 @@ class PrecisionType(StrEnum):
         }
         return dtype_map[self]
 
+    def is_mixed(self) -> bool:
+        """Check if this precision type autocasts compute around float32 weights.
+
+        Returns:
+            True for the mixed half-precision types, where trainable parameters
+            must stay in float32 storage so optimizer updates are not rounded
+            away by the low-precision dtype.
+        """
+        return self in (
+            PrecisionType.FP16_MIXED,
+            PrecisionType.BF16_MIXED,
+        )
+
+    def autocast(self, device_type: str) -> torch.autocast:
+        """Return an autocast context matching this precision.
+
+        Enabled only for the mixed half-precision types, where forward passes
+        outside the Lightning training loop must reproduce the training-time
+        autocast over mixed float32/low-precision parameters. For all other
+        precisions the returned context is a no-op.
+
+        Args:
+            device_type: Device type string for ``torch.autocast`` (e.g.
+                ``"cuda"`` or ``"cpu"``).
+        """
+        return torch.autocast(
+            device_type=device_type,
+            dtype=self.get_model_dtype() if self.is_mixed() else None,
+            enabled=self.is_mixed(),
+        )
+
     def should_convert_model(self) -> bool:
         """Check if model should be converted to a specific dtype for this precision.
 

--- a/tests/explainability/test_runner.py
+++ b/tests/explainability/test_runner.py
@@ -22,6 +22,7 @@ from versatil.explainability.constants import (
 )
 from versatil.explainability.runner import ExplainabilityRunner
 from versatil.explainability.sources.typedefs import ExplanationBatch
+from versatil.training.constants import PrecisionType
 
 
 @pytest.fixture
@@ -41,6 +42,7 @@ def runner_factory(tmp_path: Path) -> Callable[..., ExplainabilityRunner]:
         policy.eval = MagicMock()
         checkpoint_loader = MagicMock()
         checkpoint_loader.config = MagicMock()
+        checkpoint_loader.config.experiment.precision = PrecisionType.FP32.value
         checkpoint_loader.policy = policy
 
         with patch(

--- a/tests/models/decoding/generative_language_models/vision_language/test_paligemma.py
+++ b/tests/models/decoding/generative_language_models/vision_language/test_paligemma.py
@@ -874,18 +874,20 @@ class TestPaliGemmaVLMIntegration:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "precision, expected_dtype",
+        "precision, frozen, expected_dtype",
         [
-            (PrecisionType.FP32.value, torch.float32),
-            (PrecisionType.BF16_MIXED.value, torch.bfloat16),
+            (PrecisionType.FP32.value, True, torch.float32),
+            (PrecisionType.BF16_MIXED.value, True, torch.bfloat16),
+            (PrecisionType.BF16_MIXED.value, False, torch.float32),
         ],
     )
     def test_model_dtype_sets_vlm_parameter_dtype(
         self,
         real_paligemma_backbone: Callable[..., PaliGemmaVLM],
         precision: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ) -> None:
-        backbone = real_paligemma_backbone(model_dtype=precision)
+        backbone = real_paligemma_backbone(model_dtype=precision, frozen=frozen)
         param_dtype = next(backbone.vlm.parameters()).dtype
         assert param_dtype == expected_dtype

--- a/tests/models/decoding/generative_language_models/vision_language/test_smolvlm.py
+++ b/tests/models/decoding/generative_language_models/vision_language/test_smolvlm.py
@@ -940,18 +940,51 @@ class TestSmolVLMIntegration:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "precision, expected_dtype",
+        "precision, frozen, expected_dtype",
         [
-            (PrecisionType.FP32.value, torch.float32),
-            (PrecisionType.BF16_MIXED.value, torch.bfloat16),
+            (PrecisionType.FP32.value, False, torch.float32),
+            (PrecisionType.BF16_MIXED.value, True, torch.bfloat16),
+            (PrecisionType.BF16_MIXED.value, False, torch.float32),
         ],
     )
     def test_model_dtype_sets_vlm_parameter_dtype(
         self,
         real_smolvlm_backbone: Callable[..., SmolVLM],
         precision: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ) -> None:
-        backbone = real_smolvlm_backbone(model_dtype=precision)
+        backbone = real_smolvlm_backbone(model_dtype=precision, frozen=frozen)
         param_dtype = next(backbone.vlm.parameters()).dtype
         assert param_dtype == expected_dtype
+
+    @pytest.mark.integration
+    def test_lora_adapters_stay_float32_under_mixed_precision(
+        self,
+        real_smolvlm_backbone: Callable[..., SmolVLM],
+    ) -> None:
+        lora_config = LoRAAdaptation(
+            enabled=True,
+            rank=2,
+            alpha=4,
+            target_modules=(
+                LoRATargetModulePreset.VLM_TEXT_MODEL_ATTENTION_AND_FEEDFORWARD.value
+            ),
+        )
+        backbone = real_smolvlm_backbone(
+            model_dtype=PrecisionType.BF16_MIXED.value,
+            frozen=False,
+            lora_config=lora_config,
+        )
+        trainable_dtypes = {
+            parameter.dtype
+            for parameter in backbone.vlm.parameters()
+            if parameter.requires_grad
+        }
+        frozen_dtypes = {
+            parameter.dtype
+            for parameter in backbone.vlm.parameters()
+            if not parameter.requires_grad
+        }
+        assert trainable_dtypes == {torch.float32}
+        assert frozen_dtypes == {torch.bfloat16}

--- a/tests/models/encoding/encoders/cross_modal/rgbd/test_geometric_rgbd.py
+++ b/tests/models/encoding/encoders/cross_modal/rgbd/test_geometric_rgbd.py
@@ -485,35 +485,54 @@ class TestGeometricRGBDEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, expected_trainable_dtype, expected_non_trainable_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, torch.float32, torch.float32),
+            ("32", torch.float32, torch.float32),
+            ("bf16-true", torch.bfloat16, torch.bfloat16),
+            ("bf16-mixed", torch.float32, torch.bfloat16),
         ],
     )
-    def test_all_parameters_share_model_dtype_after_init(
+    def test_parameter_dtype_follows_precision_and_trainability(
         self,
         light_geometric_encoder_factory: Callable[..., GeometricRGBDEncoder],
         model_dtype: str | None,
-        expected_dtype: torch.dtype,
+        expected_trainable_dtype: torch.dtype,
+        expected_non_trainable_dtype: torch.dtype,
     ):
+        # GeometricRGBDEncoder rejects frozen=True, but the geometric decay
+        # table is a fixed non-trainable parameter that keeps the model dtype.
         encoder = light_geometric_encoder_factory(model_dtype=model_dtype)
         for parameter in encoder.parameters():
+            expected_dtype = (
+                expected_trainable_dtype
+                if parameter.requires_grad
+                else expected_non_trainable_dtype
+            )
             assert parameter.dtype == expected_dtype
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
-        [("32", torch.float32), ("bf16-mixed", torch.bfloat16)],
+        "model_dtype, expected_trainable_dtype, expected_non_trainable_dtype",
+        [
+            ("32", torch.float32, torch.float32),
+            ("bf16-true", torch.bfloat16, torch.bfloat16),
+            ("bf16-mixed", torch.float32, torch.bfloat16),
+        ],
     )
-    def test_set_image_size_preserves_model_dtype(
+    def test_set_image_size_preserves_parameter_dtype(
         self,
         light_geometric_encoder_factory: Callable[..., GeometricRGBDEncoder],
         model_dtype: str,
-        expected_dtype: torch.dtype,
+        expected_trainable_dtype: torch.dtype,
+        expected_non_trainable_dtype: torch.dtype,
     ):
         encoder = light_geometric_encoder_factory(model_dtype=model_dtype)
         encoder.set_image_size(image_height=224, image_width=224)
         for parameter in encoder.parameters():
+            expected_dtype = (
+                expected_trainable_dtype
+                if parameter.requires_grad
+                else expected_non_trainable_dtype
+            )
             assert parameter.dtype == expected_dtype

--- a/tests/models/encoding/encoders/depth/test_spatial.py
+++ b/tests/models/encoding/encoders/depth/test_spatial.py
@@ -822,16 +822,18 @@ class TestSpatialDepthEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, False, torch.float32),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
-    def test_all_parameters_share_model_dtype_after_init(
+    def test_parameter_dtype_follows_precision_and_frozen_state(
         self,
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(
@@ -843,6 +845,7 @@ class TestSpatialDepthEncoderModelDtype:
                 pooling_method=PoolingMethod.AVERAGE.value,
                 batch_norm_handling=BatchNormHandling.DEFAULT.value,
                 pretrained=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
         for parameter in encoder.parameters():
@@ -850,12 +853,17 @@ class TestSpatialDepthEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
-        [("32", torch.float32), ("bf16-mixed", torch.bfloat16)],
+        "model_dtype, frozen, expected_dtype",
+        [
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
+        ],
     )
-    def test_backbone_rebuild_preserves_model_dtype(
+    def test_backbone_rebuild_preserves_parameter_dtype(
         self,
         model_dtype: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(
@@ -867,9 +875,12 @@ class TestSpatialDepthEncoderModelDtype:
                 pooling_method=PoolingMethod.AVERAGE.value,
                 batch_norm_handling=BatchNormHandling.DEFAULT.value,
                 pretrained=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
             encoder._build_backbone(img_size=(224, 224))
+            if frozen:
+                encoder._freeze_weights()
             encoder._apply_model_dtype()
         for parameter in encoder.parameters():
             assert parameter.dtype == expected_dtype

--- a/tests/models/encoding/encoders/language/test_language.py
+++ b/tests/models/encoding/encoders/language/test_language.py
@@ -1063,21 +1063,24 @@ class TestLanguageEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, False, torch.float32),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
-    def test_embedding_only_encoder_parameters_share_model_dtype(
+    def test_embedding_only_parameter_dtype_follows_precision_and_frozen_state(
         self,
         language_encoder_factory: Callable[..., LanguageEncoder],
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         encoder = language_encoder_factory(
             pretrained=False,
+            frozen=frozen,
             pooling_method=PoolingMethod.NONE.value,
             use_embeddings_only=True,
             model_dtype=model_dtype,
@@ -1094,16 +1097,18 @@ class TestLanguageEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
     def test_full_encoder_pooling_head_matches_backbone_dtype(
         self,
         language_encoder_factory: Callable[..., LanguageEncoder],
         model_dtype: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         # Build against a real nn.Module backbone (not just MagicMock) so
@@ -1111,6 +1116,7 @@ class TestLanguageEncoderModelDtype:
         mock_backbone = torch.nn.Linear(HIDDEN_SIZE, HIDDEN_SIZE)
         encoder = language_encoder_factory(
             pretrained=True,
+            frozen=frozen,
             pooling_method=PoolingMethod.DEFAULT.value,
             use_embeddings_only=False,
             model_dtype=model_dtype,

--- a/tests/models/encoding/encoders/proprioceptive/test_base.py
+++ b/tests/models/encoding/encoders/proprioceptive/test_base.py
@@ -321,11 +321,12 @@ class TestProprioceptiveEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, False, torch.float32),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
     def test_deferred_mlp_build_respects_model_dtype(
@@ -333,11 +334,13 @@ class TestProprioceptiveEncoderModelDtype:
         proprioceptive_encoder_factory: Callable[..., ProprioceptiveEncoder],
         proprioceptive_input_factory: Callable[..., dict[str, torch.Tensor]],
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         encoder = proprioceptive_encoder_factory(
             hidden_dimensions=[32, 16],
             output_dimension=8,
+            frozen=frozen,
             model_dtype=model_dtype,
         )
         assert encoder.network is None

--- a/tests/models/encoding/encoders/rgb/test_conditional_cnn.py
+++ b/tests/models/encoding/encoders/rgb/test_conditional_cnn.py
@@ -917,16 +917,18 @@ class TestConditionalCNNEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, False, torch.float32),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
-    def test_all_parameters_share_model_dtype_after_init(
+    def test_parameter_dtype_follows_precision_and_frozen_state(
         self,
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(
@@ -942,6 +944,7 @@ class TestConditionalCNNEncoderModelDtype:
                 pooling_method=PoolingMethod.SPATIAL_SOFTMAX.value,
                 batch_norm_handling=BatchNormHandling.DEFAULT.value,
                 pretrained=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
         for parameter in encoder.parameters():

--- a/tests/models/encoding/encoders/rgb/test_flat.py
+++ b/tests/models/encoding/encoders/rgb/test_flat.py
@@ -1155,16 +1155,18 @@ class TestFlatRGBEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, False, torch.float32),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
-    def test_all_parameters_share_model_dtype_after_init(
+    def test_parameter_dtype_follows_precision_and_frozen_state(
         self,
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(FlatRGBEncoder, "_build_backbone", _real_flat_build_backbone):
@@ -1173,7 +1175,7 @@ class TestFlatRGBEncoderModelDtype:
                 backbone=FlatBackboneType.DINOV2_VITS14.value,
                 pooling_method=PoolingMethod.DEFAULT.value,
                 pretrained=False,
-                frozen=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
         for parameter in encoder.parameters():
@@ -1181,12 +1183,17 @@ class TestFlatRGBEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
-        [("32", torch.float32), ("bf16-mixed", torch.bfloat16)],
+        "model_dtype, frozen, expected_dtype",
+        [
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
+        ],
     )
-    def test_set_image_size_rebuild_preserves_model_dtype(
+    def test_set_image_size_rebuild_preserves_parameter_dtype(
         self,
         model_dtype: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(FlatRGBEncoder, "_build_backbone", _real_flat_build_backbone):
@@ -1195,7 +1202,7 @@ class TestFlatRGBEncoderModelDtype:
                 backbone=FlatBackboneType.DINOV2_VITS14.value,
                 pooling_method=PoolingMethod.DEFAULT.value,
                 pretrained=False,
-                frozen=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
             encoder.set_image_size(image_height=224, image_width=224)

--- a/tests/models/encoding/encoders/rgb/test_spatial.py
+++ b/tests/models/encoding/encoders/rgb/test_spatial.py
@@ -823,6 +823,25 @@ def _real_backbone_build_backbone(self, img_size: tuple[int, int] | None = None)
     self.backbone = backbone
 
 
+class _FeaturesOnlyConvBackbone(torch.nn.Module):
+    """Real conv backbone mimicking timm features_only list output."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 16, kernel_size=3)
+        self.feature_info = MagicMock()
+        self.feature_info.channels.return_value = [16]
+        self.patch_embed = None
+
+    def forward(self, images: torch.Tensor) -> list[torch.Tensor]:
+        return [self.conv(images)]
+
+
+def _features_only_build_backbone(self, img_size: tuple[int, int] | None = None):
+    """Side-effect installing a forward-capable features_only backbone."""
+    self.backbone = _FeaturesOnlyConvBackbone()
+
+
 class TestSpatialRGBEncoderModelDtype:
     @pytest.mark.unit
     def test_apply_model_dtype_called_once_in_init(self):
@@ -856,16 +875,18 @@ class TestSpatialRGBEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            (None, False, torch.float32),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
-    def test_all_parameters_share_model_dtype_after_init(
+    def test_parameter_dtype_follows_precision_and_frozen_state(
         self,
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(
@@ -877,6 +898,7 @@ class TestSpatialRGBEncoderModelDtype:
                 pooling_method=PoolingMethod.AVERAGE.value,
                 batch_norm_handling=BatchNormHandling.DEFAULT.value,
                 pretrained=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
         for parameter in encoder.parameters():
@@ -884,15 +906,17 @@ class TestSpatialRGBEncoderModelDtype:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            ("32", torch.float32),
-            ("bf16-mixed", torch.bfloat16),
+            ("32", False, torch.float32),
+            ("bf16-mixed", True, torch.bfloat16),
+            ("bf16-mixed", False, torch.float32),
         ],
     )
-    def test_backbone_rebuild_preserves_model_dtype(
+    def test_backbone_rebuild_preserves_parameter_dtype(
         self,
         model_dtype: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
         with patch.object(
@@ -904,9 +928,33 @@ class TestSpatialRGBEncoderModelDtype:
                 pooling_method=PoolingMethod.AVERAGE.value,
                 batch_norm_handling=BatchNormHandling.DEFAULT.value,
                 pretrained=False,
+                frozen=frozen,
                 model_dtype=model_dtype,
             )
             encoder._build_backbone(img_size=(224, 224))
+            if frozen:
+                encoder._freeze_weights()
             encoder._apply_model_dtype()
         for parameter in encoder.parameters():
             assert parameter.dtype == expected_dtype
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("frozen", [False, True])
+    def test_set_image_size_mock_forward_runs_under_mixed_precision(
+        self,
+        frozen: bool,
+    ):
+        with patch.object(
+            SpatialRGBEncoder, "_build_backbone", _features_only_build_backbone
+        ):
+            encoder = SpatialRGBEncoder(
+                input_keys="left",
+                backbone=SpatialBackboneType.RESNET18.value,
+                pooling_method=PoolingMethod.AVERAGE.value,
+                batch_norm_handling=BatchNormHandling.DEFAULT.value,
+                pretrained=False,
+                frozen=frozen,
+                model_dtype="bf16-mixed",
+            )
+            encoder.set_image_size(image_height=224, image_width=224)
+        assert encoder.pooling_head is not None

--- a/tests/models/encoding/encoders/test_base.py
+++ b/tests/models/encoding/encoders/test_base.py
@@ -36,11 +36,15 @@ class ConcreteEncodingMixin(EncodingMixin):
             model_dtype=model_dtype,
         )
         self.linear = nn.Linear(64, 64)
+        if frozen:
+            self._freeze_weights()
         self._apply_model_dtype()
 
     def rebuild(self) -> None:
         """Simulates a deferred rebuild (e.g. set_image_size / _build_network)."""
         self.linear = nn.Linear(64, 64)
+        if self.frozen:
+            self._freeze_weights()
         self._apply_model_dtype()
 
     def get_output_specification(self) -> list[FeatureMetadata]:
@@ -300,6 +304,42 @@ class TestEncodingMixinFreezeWeights:
         assert encoder.linear.training is True
 
 
+class TestEncodingMixinProbeHelpers:
+    @pytest.mark.parametrize(
+        "model_dtype, expected_mock_input_dtype, expected_autocast_enabled",
+        [
+            (None, torch.float32, False),
+            (PrecisionType.FP32.value, torch.float32, False),
+            (PrecisionType.BF16_MIXED.value, torch.float32, True),
+            (PrecisionType.BF16_TRUE.value, torch.bfloat16, False),
+        ],
+    )
+    def test_mock_forward_runs_under_autocast_only_for_mixed_precision(
+        self,
+        concrete_encoder_factory: Callable[..., ConcreteEncodingMixin],
+        model_dtype: str | None,
+        expected_mock_input_dtype: torch.dtype,
+        expected_autocast_enabled: bool,
+    ):
+        encoder = concrete_encoder_factory(model_dtype=model_dtype)
+        assert encoder._mock_forward_dtype() == expected_mock_input_dtype
+        with encoder._mock_forward_autocast():
+            assert torch.is_autocast_enabled("cpu") == expected_autocast_enabled
+
+    def test_mock_forward_matches_dtypes_of_frozen_mixed_precision_encoder(
+        self,
+        concrete_encoder_factory: Callable[..., ConcreteEncodingMixin],
+    ):
+        encoder = concrete_encoder_factory(
+            model_dtype=PrecisionType.BF16_MIXED.value,
+            frozen=True,
+        )
+        mock_input = torch.zeros(1, 64, dtype=encoder._mock_forward_dtype())
+        with torch.no_grad(), encoder._mock_forward_autocast():
+            output = encoder.linear(mock_input)
+        assert output.shape == (1, 64)
+
+
 class TestEncodingMixinGetVocabSize:
     def test_returns_none_by_default(
         self,
@@ -356,39 +396,56 @@ class TestEncodingMixinModelDtype:
 
 class TestEncodingMixinApplyModelDtype:
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
+        "model_dtype, frozen, expected_dtype",
         [
-            (None, torch.float32),
-            (PrecisionType.FP32.value, torch.float32),
-            (PrecisionType.BF16_MIXED.value, torch.bfloat16),
-            (PrecisionType.BF16_TRUE.value, torch.bfloat16),
-            (PrecisionType.FP16_MIXED.value, torch.float16),
+            (None, False, torch.float32),
+            (PrecisionType.FP32.value, False, torch.float32),
+            (PrecisionType.BF16_MIXED.value, True, torch.bfloat16),
+            (PrecisionType.BF16_TRUE.value, False, torch.bfloat16),
+            (PrecisionType.FP16_MIXED.value, True, torch.float16),
         ],
     )
-    def test_all_parameters_share_model_dtype_after_init(
+    def test_frozen_and_pure_precision_parameters_take_model_dtype(
         self,
         concrete_encoder_factory: Callable[..., ConcreteEncodingMixin],
         model_dtype: str | None,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
-        encoder = concrete_encoder_factory(model_dtype=model_dtype)
+        encoder = concrete_encoder_factory(model_dtype=model_dtype, frozen=frozen)
         for parameter in encoder.parameters():
             assert parameter.dtype == expected_dtype
 
     @pytest.mark.parametrize(
-        "model_dtype, expected_dtype",
-        [
-            (PrecisionType.FP32.value, torch.float32),
-            (PrecisionType.BF16_MIXED.value, torch.bfloat16),
-        ],
+        "model_dtype",
+        [PrecisionType.BF16_MIXED.value, PrecisionType.FP16_MIXED.value],
     )
-    def test_rebuild_preserves_model_dtype(
+    def test_trainable_parameters_stay_float32_under_mixed_precision(
         self,
         concrete_encoder_factory: Callable[..., ConcreteEncodingMixin],
         model_dtype: str,
+    ):
+        encoder = concrete_encoder_factory(model_dtype=model_dtype, frozen=False)
+        for parameter in encoder.parameters():
+            assert parameter.requires_grad is True
+            assert parameter.dtype == torch.float32
+
+    @pytest.mark.parametrize(
+        "model_dtype, frozen, expected_dtype",
+        [
+            (PrecisionType.FP32.value, False, torch.float32),
+            (PrecisionType.BF16_MIXED.value, True, torch.bfloat16),
+            (PrecisionType.BF16_MIXED.value, False, torch.float32),
+        ],
+    )
+    def test_rebuild_preserves_parameter_dtype_contract(
+        self,
+        concrete_encoder_factory: Callable[..., ConcreteEncodingMixin],
+        model_dtype: str,
+        frozen: bool,
         expected_dtype: torch.dtype,
     ):
-        encoder = concrete_encoder_factory(model_dtype=model_dtype)
+        encoder = concrete_encoder_factory(model_dtype=model_dtype, frozen=frozen)
         encoder.rebuild()
         for parameter in encoder.parameters():
             assert parameter.dtype == expected_dtype

--- a/tests/training/conftest.py
+++ b/tests/training/conftest.py
@@ -20,6 +20,7 @@ from versatil.models.decoding.algorithm.base import DecodingAlgorithm
 from versatil.models.decoding.decoders.base import ActionDecoder, DecoderInput
 from versatil.models.encoding.pipeline import EncodingPipeline
 from versatil.models.policy import Policy
+from versatil.training.constants import PrecisionType
 from versatil.training.lightning_policy import LightningPolicy
 
 
@@ -218,6 +219,7 @@ def mock_trainer_factory() -> Callable[..., Mock]:
         val_dataloaders: Mock | None = None,
         accumulate_grad_batches: int = 1,
         is_last_batch: bool = False,
+        precision: str = PrecisionType.FP32.value,
     ) -> Mock:
         trainer = MagicMock(spec="pl.Trainer")
         trainer.current_epoch = current_epoch
@@ -225,6 +227,7 @@ def mock_trainer_factory() -> Callable[..., Mock]:
         trainer.max_epochs = max_epochs
         trainer.estimated_stepping_batches = estimated_stepping_batches
         trainer.sanity_checking = sanity_checking
+        trainer.precision = precision
         trainer.val_dataloaders = val_dataloaders
         trainer.accumulate_grad_batches = accumulate_grad_batches
         trainer.is_last_batch = is_last_batch

--- a/tests/training/test_callbacks/conftest.py
+++ b/tests/training/test_callbacks/conftest.py
@@ -95,6 +95,7 @@ def mock_pl_module_factory() -> Callable[..., MagicMock]:
         ).return_value = val_metrics_return
         if policy_training is not None:
             pl_module.policy.training = policy_training
+        pl_module.device = torch.device("cpu")
         return pl_module
 
     return factory

--- a/tests/training/test_callbacks/test_prior_target_standardization.py
+++ b/tests/training/test_callbacks/test_prior_target_standardization.py
@@ -15,9 +15,16 @@ from versatil.models.decoding.latent.prior.latent_standardizer import (
 from versatil.training.callbacks.prior_target_standardization import (
     PriorTargetStandardizationCallback,
 )
+from versatil.training.constants import PrecisionType
 from versatil.training.lightning_policy import LightningPolicy
 
 LATENT_DIMENSION = 2
+
+
+def _mock_trainer() -> MagicMock:
+    trainer = MagicMock()
+    trainer.precision = PrecisionType.FP32.value
+    return trainer
 
 
 class _ToyEncodingPipeline(torch.nn.Module):
@@ -219,7 +226,7 @@ class TestPriorTargetStandardizationCallback:
         lightning_policy.policy.train()
         callback = PriorTargetStandardizationCallback()
 
-        callback.on_train_start(trainer=MagicMock(), pl_module=lightning_policy)
+        callback.on_train_start(trainer=_mock_trainer(), pl_module=lightning_policy)
 
         expected_targets = torch.tensor(
             [[1.0, 2.0], [3.0, 4.0], [6.0, 7.0]],
@@ -252,7 +259,7 @@ class TestPriorTargetStandardizationCallback:
         )
         callback = PriorTargetStandardizationCallback(max_batches=1)
 
-        callback.on_train_start(trainer=MagicMock(), pl_module=lightning_policy)
+        callback.on_train_start(trainer=_mock_trainer(), pl_module=lightning_policy)
 
         expected_targets = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         standardizer = lightning_policy.policy.algorithm.prior.latent_standardizer
@@ -290,7 +297,7 @@ class TestPriorTargetStandardizationCallback:
             "encode",
             wraps=posterior_encoder.encode,
         ) as encode_spy:
-            callback.on_train_start(trainer=MagicMock(), pl_module=lightning_policy)
+            callback.on_train_start(trainer=_mock_trainer(), pl_module=lightning_policy)
 
         standardizer = lightning_policy.policy.algorithm.prior.latent_standardizer
         assert standardizer.is_fitted.item() is False
@@ -336,7 +343,7 @@ class TestPriorTargetStandardizationCallback:
                 f"'{SampleKey.ACTION.value}' keys."
             ),
         ):
-            callback.on_train_start(trainer=MagicMock(), pl_module=lightning_policy)
+            callback.on_train_start(trainer=_mock_trainer(), pl_module=lightning_policy)
 
     def test_non_lightning_policy_module_raises(self) -> None:
         callback = PriorTargetStandardizationCallback()
@@ -349,7 +356,7 @@ class TestPriorTargetStandardizationCallback:
             ),
         ):
             callback.on_train_start(
-                trainer=MagicMock(), pl_module=not_a_lightning_policy
+                trainer=_mock_trainer(), pl_module=not_a_lightning_policy
             )
 
     def test_target_latent_dimension_mismatch_raises(
@@ -376,7 +383,7 @@ class TestPriorTargetStandardizationCallback:
                 f"{LATENT_DIMENSION}, got {wrong_dimension}."
             ),
         ):
-            callback.on_train_start(trainer=MagicMock(), pl_module=lightning_policy)
+            callback.on_train_start(trainer=_mock_trainer(), pl_module=lightning_policy)
 
     def test_empty_dataloader_raises(
         self,
@@ -396,4 +403,4 @@ class TestPriorTargetStandardizationCallback:
                 "from an empty training dataloader."
             ),
         ):
-            callback.on_train_start(trainer=MagicMock(), pl_module=lightning_policy)
+            callback.on_train_start(trainer=_mock_trainer(), pl_module=lightning_policy)

--- a/tests/training/test_constants.py
+++ b/tests/training/test_constants.py
@@ -1,0 +1,52 @@
+"""Tests for versatil.training.constants module."""
+
+import pytest
+import torch
+
+from versatil.training.constants import PrecisionType
+
+
+class TestPrecisionTypeIsMixed:
+    @pytest.mark.parametrize(
+        "precision, expected",
+        [
+            (PrecisionType.FP32, False),
+            (PrecisionType.FP16_MIXED, True),
+            (PrecisionType.BF16_MIXED, True),
+            (PrecisionType.FP16_TRUE, False),
+            (PrecisionType.BF16_TRUE, False),
+            (PrecisionType.FP64, False),
+            (PrecisionType.INT8, False),
+        ],
+    )
+    def test_only_mixed_half_precisions_are_mixed(
+        self,
+        precision: PrecisionType,
+        expected: bool,
+    ):
+        assert precision.is_mixed() is expected
+
+
+class TestPrecisionTypeAutocast:
+    @pytest.mark.parametrize(
+        "precision, expected_enabled",
+        [
+            (PrecisionType.FP32, False),
+            (PrecisionType.BF16_MIXED, True),
+            (PrecisionType.FP16_MIXED, True),
+            (PrecisionType.BF16_TRUE, False),
+        ],
+    )
+    def test_enabled_only_for_mixed_precisions(
+        self,
+        precision: PrecisionType,
+        expected_enabled: bool,
+    ):
+        with precision.autocast(device_type="cpu"):
+            assert torch.is_autocast_enabled("cpu") is expected_enabled
+
+    def test_mixed_precision_context_casts_compute_to_model_dtype(self):
+        linear = torch.nn.Linear(4, 4)
+        with PrecisionType.BF16_MIXED.autocast(device_type="cpu"):
+            output = linear(torch.zeros(1, 4))
+        assert output.dtype == torch.bfloat16


### PR DESCRIPTION
## Problem

Autoregressive OpenVLA scored 2/130 on libero_spatial. Root cause: `model_dtype: bf16-mixed` cast the whole VLM to bf16, LoRA adapters included, and AdamW then kept its moments in bf16 too. At lr 2.5e-5 essentially every adapter update rounded to zero against the bf16 resolution of the weights, so after 84k optimizer steps the `lora_A` matrices were still at their exact random init and the policy degenerated to a constant "don't move" action.

## Fix

- `_apply_model_dtype()` (encoder and generative-LM base classes) re-casts `requires_grad` parameters to float32 for the mixed precisions. Frozen weights and buffers keep the low-precision dtype, so the memory savings on frozen backbones are untouched. Autocast handles the compute, which is what `bf16-mixed` means everywhere else: float32 masters, low-precision kernels.
- `PrecisionType` gains `is_mixed()` and `autocast(device_type)`.
- OpenVLA and OpenVLA-OFT presets train LoRA at the recipe lr of 5e-4 (the working OFT run already used it; 2.5e-5 is the full-fine-tune lr).

## Consequential fixes

- `set_image_size` mock forwards run under autocast so shape inference works on mixed float32/bf16 trees.
- `SyntheticRolloutCallback`, `PriorTargetStandardizationCallback`, and explainability attribution now run their forwards under the training autocast. These crashed for **any** bf16-mixed policy, on main too (pre-existing, exposed by the smoke test below).
- `DFormerV2.set_image_size` re-freezes the rebuilt pooling head on frozen encoders.
- The heatmap writer casts to float32 before numpy conversion (numpy has no bfloat16).

## Verification

- Full unit suite (10286) and integration suite (808) pass.
- A 1-epoch `bf16-mixed` synthetic training with a bf16 encoder runs end to end, including the rollout callback and checkpoint save; the identical run crashes on main.
- An audit of every forward-pass site in the repo confirmed each runs under the Lightning plugin, an explicit precision-derived autocast, or an intentionally uniform-dtype export path.

Retrain watchpoints for OpenVLA: `lora_A` std should leave 0.03125 within a few hundred steps, and val token CE should drop below ~2.0 by the end of epoch 0.