### PR TITLE
Bump main to 0.5.0.dev0 and verify releases after publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,3 +39,43 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  verify-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Wait for the release to appear on PyPI
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          for attempt in $(seq 1 40); do
+            curl -sf "https://pypi.org/pypi/versatil/${version}/json" > /dev/null && exit 0
+            sleep 15
+          done
+          echo "versatil ${version} did not appear on PyPI in time" >&2
+          exit 1
+      - name: Verify pip resolves the released version in a clean venv
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          python -m venv pip-env
+          pip-env/bin/pip install --quiet versatil
+          installed="$(pip-env/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("versatil"))')"
+          test "$installed" = "$version" || { echo "pip installed ${installed}, expected ${version}" >&2; exit 1; }
+      - name: Verify uv resolves the released version in a clean venv
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          uv venv uv-env
+          VIRTUAL_ENV=uv-env uv pip install --quiet versatil --prerelease=allow
+          installed="$(uv-env/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("versatil"))')"
+          test "$installed" = "$version" || { echo "uv installed ${installed}, expected ${version}" >&2; exit 1; }
+      - name: Run a synthetic training smoke test on the published wheel
+        run: |
+          pip-env/bin/python -m versatil.endpoints.train \
+            --config-name end_to_end_training_runs/synthetic/bcat \
+            experiment.device=cpu \
+            experiment.use_wandb=false \
+            training.num_epochs=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mixed-precision training keeps trainable parameters in float32 storage, so optimizer updates no longer round away in bf16. This unblocks autoregressive OpenVLA LoRA fine-tuning, whose adapters previously never left their initialization.
 - Forward passes outside the Lightning loop (synthetic rollout evaluation, prior target standardization, explainability attribution, encoder shape probing) run under the same autocast as training instead of crashing on mixed-precision policies.
 
+### Added
+- The publish workflow verifies each release by installing it from PyPI in clean pip and uv environments and running a training smoke test.
+
 ### Changed
 - OpenVLA and OpenVLA-OFT presets train LoRA with the recipe learning rate of 5e-4.
+- main carries a `.dev` version between releases so source installs are distinguishable from PyPI releases.
 
 ## [0.4.1] - 2026-07-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "VersatIL"
-version = "0.4.1"
+version = "0.5.0.dev0"
 description = "Modular imitation learning framework for training, compressing, and deploying robot manipulation policies"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3801,7 +3801,7 @@ wheels = [
 
 [[package]]
 name = "versatil"
-version = "0.4.1"
+version = "0.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Two release-hygiene changes:

- **Dev versioning**: main now carries `0.5.0.dev0` between releases, so source installs report an unreleased version instead of shadowing the released 0.4.1. 

- **Post-publish verification**: the publish workflow has a `verify-release` job that runs after every PyPI upload. It waits for the release to appear on PyPI, installs it in clean venvs with both `pip` and `uv pip install --prerelease=allow`, asserts the resolved version matches the tag, and runs a one-epoch synthetic CPU training on the published wheel. 