### PR TITLE
Support macOS (Apple Silicon) for CPU workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,42 @@ jobs:
           name: unit-test-report-${{ matrix.python-version }}
           path: report-unit.xml
 
+  macos-unit-tests:
+    runs-on: macos-15
+    needs: [ruff-format, ruff-lint]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: pyproject.toml
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-macos-${{ hashFiles('pyproject.toml') }}
+          restore-keys: hf-models-macos-
+      - name: Create .env for CI
+        run: |
+          cat > .env << 'EOF'
+          VERSATIL_CACHE_DIR=/tmp/versatil/cache
+          VERSATIL_CHECKPOINT_DIR=/tmp/versatil/checkpoints
+          VERSATIL_ZARR_DIR=/tmp/versatil/zarr
+          EOF
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.14
+          source .venv/bin/activate
+          uv sync --python 3.14 --extra cpu
+      - name: Run unit tests
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/ -m "not integration and not slow and not requires_gpu and not requires_executorch" --tb=short -q
+
   integration-tests:
     runs-on: ubuntu-latest
     needs: [ruff-format, ruff-lint]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forward passes outside the Lightning loop (synthetic rollout evaluation, prior target standardization, explainability attribution, encoder shape probing) run under the same autocast as training instead of crashing on mixed-precision policies.
 
 ### Added
+- macOS (Apple Silicon) support for CPU workflows: dependency resolution covers darwin arm64 wheels and CI runs the unit suite on a macOS runner. GPU training and the `gpu` extra remain Linux-only.
 - The publish workflow verifies each release by installing it from PyPI in clean pip and uv environments and running a training smoke test.
 
 ### Changed

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,8 +4,9 @@
 
 | Requirement | Minimum Version | Notes |
 |-------------|----------------|-------|
+| OS | Linux (x86_64/aarch64) or macOS (Apple Silicon) | macOS runs CPU-only; GPU training requires Linux. |
 | Python | 3.13 or 3.14 | Supported by `pyproject.toml` (`requires-python = ">=3.13,<3.15"`). |
-| CUDA driver | Supports CUDA 13.0 runtime | Required only when installing the `gpu` extra |
+| CUDA driver | Supports CUDA 13.0 runtime | Required only when installing the `gpu` extra on Linux |
 | Git | Latest | Credentials for private repositories if applicable |
 
 ## Setup
@@ -102,6 +103,10 @@ uv sync --python "$PYTHON_VERSION" --extra gpu
 # For CPU-only environments:
 # uv sync --python "$PYTHON_VERSION" --extra cpu
 ```
+
+On macOS use `--extra cpu`; the `gpu` extra is Linux-only and installs
+nothing on other platforms. macOS installs receive the MPS-enabled PyTorch
+build from PyPI, but VersatIL runs on the CPU device.
 
 Both source setup paths install:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,9 @@ cpu = [
   "torchvision>=0.27,<0.28",
 ]
 gpu = [
-  "torch>=2.12,<2.13",
-  "torchao>=0.17,<0.18",
-  "torchvision>=0.27,<0.28",
+  "torch>=2.12,<2.13; sys_platform == 'linux'",
+  "torchao>=0.17,<0.18; sys_platform == 'linux'",
+  "torchvision>=0.27,<0.28; sys_platform == 'linux'",
 ]
 executorch = [
   "executorch>=1.3.1,<1.4; python_version < '3.14'",
@@ -125,6 +125,11 @@ name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+explicit = true
+
 [tool.uv]
 conflicts = [
   [
@@ -137,21 +142,26 @@ required-environments = [
   "python_version == '3.14' and sys_platform == 'linux' and platform_machine == 'x86_64'",
   "python_version == '3.13' and sys_platform == 'linux' and platform_machine == 'aarch64'",
   "python_version == '3.14' and sys_platform == 'linux' and platform_machine == 'aarch64'",
+  "python_version == '3.13' and sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "python_version == '3.14' and sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 
 [tool.uv.sources]
 torch = [
-  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pypi", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-cpu", extra = "cpu", marker = "sys_platform == 'linux'" },
   { index = "pytorch-cpu", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },
   { index = "pytorch-cu130", extra = "gpu", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]
 torchao = [
-  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pypi", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-cpu", extra = "cpu", marker = "sys_platform == 'linux'" },
   { index = "pytorch-cpu", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },
   { index = "pytorch-cu130", extra = "gpu", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]
 torchvision = [
-  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pypi", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-cpu", extra = "cpu", marker = "sys_platform == 'linux'" },
   { index = "pytorch-cpu", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },
   { index = "pytorch-cu130", extra = "gpu", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ dependencies = [
   "pytorch-lightning>=2.6",
   "pyyaml>=6.0",
   "safetensors>=0.6",
-  "scikit-learn>=1.7.1",
+  # executorch 1.3.1 pins scikit-learn 1.7.1, but only 1.7.2+ ships
+  # Python 3.14 wheels; the marker split keeps both installable.
+  "scikit-learn>=1.7.1; python_version < '3.14'",
+  "scikit-learn>=1.7.2; python_version >= '3.14'",
   "scipy>=1.16",
   "seaborn>=0.13",
   "termcolor>=3.2",

--- a/src/versatil/quantization/torch_patches.py
+++ b/src/versatil/quantization/torch_patches.py
@@ -90,6 +90,24 @@ _QAT_MODULE_PATCHES: dict[str, list[SourcePatch]] = {
 }
 
 
+# torch's darwin arm64 build ships no mkldnn ops; torchao's x86 inductor
+# passes call torch.ops.mkldnn._is_mkldnn_acl_supported() at import time,
+# which raises AttributeError on macOS. The guard keeps upstream's intent:
+# the fusion registrations are skipped wherever mkldnn is unavailable.
+_INDUCTOR_MODULE_PATCHES: dict[str, list[SourcePatch]] = {
+    "torchao.quantization.pt2e.inductor_passes.x86": [
+        SourcePatch(
+            original="if not torch.ops.mkldnn._is_mkldnn_acl_supported():",
+            replacement=(
+                'if hasattr(torch.ops.mkldnn, "_is_mkldnn_acl_supported") '
+                "and not torch.ops.mkldnn._is_mkldnn_acl_supported():"
+            ),
+            required=False,
+        ),
+    ],
+}
+
+
 class PatchingSourceLoader(importlib.machinery.SourceFileLoader):
     """Source loader applying string replacements before compilation."""
 
@@ -197,6 +215,8 @@ def register_torchao_patches() -> None:
     module_patches = dict(_QAT_MODULE_PATCHES)
     if sys.version_info >= (3, 14):
         module_patches.update(_PT2E_MODULE_PATCHES)
+    if sys.platform == "darwin":
+        module_patches.update(_INDUCTOR_MODULE_PATCHES)
     already_imported = [name for name in module_patches if name in sys.modules]
     if already_imported:
         logging.warning(

--- a/uv.lock
+++ b/uv.lock
@@ -2,34 +2,27 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <3.15"
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
 ]
 required-markers = [
     "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 conflicts = [[
     { package = "versatil", extra = "cpu" },
@@ -47,10 +40,9 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/60/2757c4f03a8705dbf80b1268b03881927878dca5ed07d74f733fb6c219e0/accelerate-1.11.0.tar.gz", hash = "sha256:bb1caf2597b4cd632b917b5000c591d10730bb024a79746f1ee205bba80bd229", size = 393715, upload-time = "2025-10-20T14:42:25.025Z" }
 wheels = [
@@ -293,8 +285,8 @@ name = "cattrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
 wheels = [
@@ -502,14 +494,14 @@ name = "coremltools"
 version = "9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "cattrs", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "numpy", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "protobuf", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pyaml", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "tqdm", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cattrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/e6/8cb11a246f61736e75b20488b9c3cf9c208f500c9a3f92d717dbf592348c/coremltools-9.0.tar.gz", hash = "sha256:4ff346b29c31c4b45acd19a20e0f0a1ac65180a96776e62f15bd5c46f4926687", size = 1656978, upload-time = "2025-11-10T21:51:23.855Z" }
 wheels = [
@@ -621,7 +613,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-pathfinder", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -653,34 +645,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cufft", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-curand", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 
 [[package]]
@@ -738,32 +730,31 @@ name = "executorch"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coremltools", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "expecttest", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "flatbuffers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "hydra-core", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "hypothesis", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "kgb", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "mpmath", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "omegaconf", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "packaging", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pandas", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "parameterized", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pytorch-tokenizers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pyyaml", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "ruamel-yaml", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "scikit-learn", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "tabulate", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (python_full_version < '3.14' and platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (python_full_version < '3.14' and platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu') or (python_full_version < '3.14' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "coremltools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "expecttest" },
+    { name = "flatbuffers" },
+    { name = "hydra-core" },
+    { name = "hypothesis" },
+    { name = "kgb" },
+    { name = "mpmath" },
+    { name = "numpy" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "parameterized" },
+    { name = "pytorch-tokenizers" },
+    { name = "pyyaml" },
+    { name = "ruamel-yaml" },
+    { name = "scikit-learn" },
+    { name = "sympy" },
+    { name = "tabulate" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2c/9c4a5984f104d6a6cb8f41f142c4b128ae1b34852ce7ef51bd9bd5da6c75/executorch-1.3.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:08ddb9b4445e25d39bfaa21b75ef1fff321ed67e4c6d82afdb97003614aac793", size = 15619269, upload-time = "2026-05-29T17:04:21.046Z" },
@@ -924,10 +915,9 @@ version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/f4/f888e6a2f59da7e743b93532aa90a8b02bc7f828273263014b8e7bb3e1c1/geomloss-0.2.6.tar.gz", hash = "sha256:491c47085c5001b2cb6128ea541fd2d0a8808ae50e88a0798c7853c9d995faeb", size = 26752, upload-time = "2023-04-28T17:25:34.545Z" }
 
@@ -1128,7 +1118,7 @@ name = "hypothesis"
 version = "6.155.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sortedcontainers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sortedcontainers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz", hash = "sha256:d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea", size = 478291, upload-time = "2026-06-21T05:54:31.573Z" }
 wheels = [
@@ -1287,10 +1277,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -1824,7 +1813,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1867,7 +1856,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1880,7 +1869,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1912,9 +1901,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1927,7 +1916,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2101,10 +2090,9 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -2351,7 +2339,7 @@ name = "pyaml"
 version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (python_full_version < '3.14' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/fb/2b9590512a9d7763620d87171c7531d5295678ce96e57393614b91da8998/pyaml-26.2.1.tar.gz", hash = "sha256:489dd82997235d4cfcf76a6287fce2f075487d77a6567c271e8d790583690c68", size = 30653, upload-time = "2026-02-06T13:49:30.769Z" }
 wheels = [
@@ -2598,10 +2586,9 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -2616,9 +2603,9 @@ name = "pytorch-tokenizers"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sentencepiece", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "tiktoken", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "tokenizers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sentencepiece" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/16/b7270314ff16699e54f19c8b31a86c91453a0859ae19ceadadec41548199/pytorch_tokenizers-1.3.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:2d057c3190c05808cf4954de457acce47162d8f6d5719334337e3e972b5e06c8", size = 1107320, upload-time = "2026-05-26T16:32:41.164Z" },
@@ -2887,24 +2874,11 @@ wheels = [
 name = "scikit-learn"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "scipy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/84/5f4af978fff619706b8961accac84780a6d298d82a8873446f72edb4ead0/scikit_learn-1.7.1.tar.gz", hash = "sha256:24b3f1e976a4665aa74ee0fcaac2b8fccc6ae77c8e07ab25da3ba6d3292b9802", size = 7190445, upload-time = "2025-07-18T08:01:54.5Z" }
 wheels = [
@@ -2918,48 +2892,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/80/abe18fe471af9f1d181904203d62697998b27d9b62124cd281d740ded2f9/scikit_learn-1.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1f812729e38c8cb37f760dce71a9b83ccfb04f59b3dca7c6079dcdc60544fa9e", size = 9532052, upload-time = "2025-07-18T08:01:48.676Z" },
     { url = "https://files.pythonhosted.org/packages/14/82/b21aa1e0c4cee7e74864d3a5a721ab8fcae5ca55033cb6263dca297ed35b/scikit_learn-1.7.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88e1a20131cf741b84b89567e1717f27a2ced228e0f29103426102bc2e3b8ef7", size = 9361575, upload-time = "2025-07-18T08:01:50.639Z" },
     { url = "https://files.pythonhosted.org/packages/f2/20/f4777fcd5627dc6695fa6b92179d0edb7a3ac1b91bcd9a1c7f64fa7ade23/scikit_learn-1.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b1bd1d919210b6a10b7554b717c9000b5485aa95a1d0f177ae0d7ee8ec750da5", size = 9277310, upload-time = "2025-07-18T08:01:52.547Z" },
-]
-
-[[package]]
-name = "scikit-learn"
-version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-]
-dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "numpy", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "scipy", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
-    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
-    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
-    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
-    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
-    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/82/dee5acf66837852e8e68df6d8d3a6cb22d3df997b733b032f513d95205b7/scikit_learn-1.7.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fa8f63940e29c82d1e67a45d5297bdebbcb585f5a5a50c4914cc2e852ab77f33", size = 9208906, upload-time = "2025-09-09T08:21:18.557Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/30/9029e54e17b87cb7d50d51a5926429c683d5b4c1732f0507a6c3bed9bf65/scikit_learn-1.7.2-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f95dc55b7902b91331fa4e5845dd5bde0580c9cd9612b1b2791b7e80c3d32615", size = 8627836, upload-time = "2025-09-09T08:21:20.695Z" },
-    { url = "https://files.pythonhosted.org/packages/60/18/4a52c635c71b536879f4b971c2cedf32c35ee78f48367885ed8025d1f7ee/scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9656e4a53e54578ad10a434dc1f993330568cfee176dff07112b8785fb413106", size = 9426236, upload-time = "2025-09-09T08:21:22.645Z" },
-    { url = "https://files.pythonhosted.org/packages/99/7e/290362f6ab582128c53445458a5befd471ed1ea37953d5bcf80604619250/scikit_learn-1.7.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96dc05a854add0e50d3f47a1ef21a10a595016da5b007c7d9cd9d0bffd1fcc61", size = 9312593, upload-time = "2025-09-09T08:21:24.65Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/87/24f541b6d62b1794939ae6422f8023703bbf6900378b2b34e0b4384dfefd/scikit_learn-1.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:bb24510ed3f9f61476181e4db51ce801e2ba37541def12dc9333b946fc7a9cf8", size = 8820007, upload-time = "2025-09-09T08:21:26.713Z" },
 ]
 
 [[package]]
@@ -3261,8 +3193,8 @@ name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "requests", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "regex" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
 wheels = [
@@ -3304,14 +3236,12 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
 wheels = [
@@ -3347,57 +3277,28 @@ wheels = [
 [[package]]
 name = "torch"
 version = "2.12.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", upload-time = "2026-05-12T16:20:17Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", upload-time = "2026-05-12T16:20:21Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", upload-time = "2026-05-12T16:20:26Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", upload-time = "2026-05-12T16:20:31Z" },
-]
-
-[[package]]
-name = "torch"
-version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform == 'darwin'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "filelock", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "fsspec", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "jinja2", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "networkx", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "setuptools", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "sympy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "triton", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "cuda-bindings", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "fsspec", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "jinja2", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "networkx", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "setuptools", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "triton", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
@@ -3423,12 +3324,9 @@ name = "torch"
 version = "2.12.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
     { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
@@ -3464,25 +3362,26 @@ name = "torch"
 version = "2.12.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "fsspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "networkx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cublas", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cudnn-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nccl-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "setuptools", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-bindings", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "fsspec", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "jinja2", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "networkx", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "setuptools", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "triton", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bf5f067d3a4d713b75ccd6a0141f8133c7495a016b917ce6dcec1492e3da98b0", upload-time = "2026-05-12T23:51:35Z" },
@@ -3504,14 +3403,9 @@ name = "torchao"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform == 'darwin'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/fe/a4036a8e80fa800c92dbcbf75f541cd4c106248b6b579db6dab1800f616a/torchao-0.17.0-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87a418ce0ec064a821ceab83c921b501acef0ce9a6ccd1be358fcd16c3ae8c58", size = 3206172, upload-time = "2026-03-30T22:25:52.974Z" },
@@ -3523,14 +3417,9 @@ name = "torchao"
 version = "0.17.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cpu/torchao-0.17.0%2Bcpu-py3-none-any.whl", hash = "sha256:6c0ce8b506c72be4efb1f0c6fd1679cb58145efebb20d51ac1adf7a7b3ebb872", upload-time = "2026-03-30T20:39:35Z" },
@@ -3541,8 +3430,9 @@ name = "torchao"
 version = "0.17.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cu130/torchao-0.17.0%2Bcu130-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79ddf24c7e846ac9fb856f709394c4f60932994c2a125708d39833c12ea41d87", upload-time = "2026-03-30T20:39:51Z" },
@@ -3556,10 +3446,9 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765, upload-time = "2026-03-09T17:41:22.443Z" }
 wheels = [
@@ -3569,41 +3458,16 @@ wheels = [
 [[package]]
 name = "torchvision"
 version = "0.27.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "numpy", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pillow", marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c1fac0fc2a7adf29481fc1938a0e7845c57ba1147a986784109c4d98f434ea8c", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2c4099a15150143b9b034730b404a56d572efe0b79489b4c765d929cb4eac7f3", upload-time = "2026-05-12T16:20:37Z" },
-]
-
-[[package]]
-name = "torchvision"
-version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "python_full_version < '3.14' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "sys_platform == 'darwin'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
@@ -3629,12 +3493,9 @@ name = "torchvision"
 version = "0.27.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
@@ -3661,13 +3522,14 @@ name = "torchvision"
 version = "0.27.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pillow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:da81245777c47f6dfd60e02f510d9778fb7f6e23119e2fc1ea1bb06777aae338", upload-time = "2026-05-12T16:20:44Z" },
@@ -3829,24 +3691,21 @@ dependencies = [
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "scikit-learn", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
     { name = "termcolor" },
     { name = "threadpoolctl" },
     { name = "timm" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
-    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu')" },
-    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "tso-robotics-sockets" },
@@ -3857,10 +3716,11 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 docs = [
@@ -3873,15 +3733,12 @@ executorch = [
     { name = "executorch", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 gpu = [
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 
 [package.dev-dependencies]
@@ -3930,27 +3787,36 @@ requires-dist = [
     { name = "termcolor", specifier = ">=3.2" },
     { name = "threadpoolctl", specifier = ">=3.6" },
     { name = "timm", specifier = ">=1.0.27" },
-    { name = "torch", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'", specifier = ">=2.12,<2.13" },
+    { name = "torch", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')", specifier = ">=2.12,<2.13" },
+    { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.12,<2.13", index = "https://pypi.org/simple" },
+    { name = "torch", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = ">=2.12,<2.13", index = "https://pypi.org/simple" },
+    { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'cpu'", specifier = ">=2.12,<2.13" },
     { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=2.12,<2.13", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'cpu'", specifier = ">=2.12,<2.13", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=2.12,<2.13", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=2.12,<2.13" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=2.12,<2.13", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "versatil", extra = "gpu" } },
-    { name = "torch", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'gpu') or (sys_platform != 'linux' and extra == 'gpu')", specifier = ">=2.12,<2.13" },
-    { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.12,<2.13", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "versatil", extra = "cpu" } },
-    { name = "torchao", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'", specifier = ">=0.17,<0.18" },
+    { name = "torch", marker = "sys_platform == 'linux' and extra == 'cpu'", specifier = ">=2.12,<2.13", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "versatil", extra = "cpu" } },
+    { name = "torchao", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')", specifier = ">=0.17,<0.18" },
+    { name = "torchao", marker = "sys_platform == 'darwin'", specifier = ">=0.17,<0.18", index = "https://pypi.org/simple" },
+    { name = "torchao", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = ">=0.17,<0.18", index = "https://pypi.org/simple" },
+    { name = "torchao", marker = "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'cpu'", specifier = ">=0.17,<0.18" },
     { name = "torchao", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=0.17,<0.18", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchao", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'cpu'", specifier = ">=0.17,<0.18", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchao", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.17,<0.18", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchao", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.17,<0.18" },
     { name = "torchao", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.17,<0.18", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "versatil", extra = "gpu" } },
-    { name = "torchao", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'gpu') or (sys_platform != 'linux' and extra == 'gpu')", specifier = ">=0.17,<0.18" },
-    { name = "torchao", marker = "extra == 'cpu'", specifier = ">=0.17,<0.18", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "versatil", extra = "cpu" } },
-    { name = "torchvision", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'", specifier = ">=0.27,<0.28" },
+    { name = "torchao", marker = "sys_platform == 'linux' and extra == 'cpu'", specifier = ">=0.17,<0.18", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "versatil", extra = "cpu" } },
+    { name = "torchvision", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')", specifier = ">=0.27,<0.28" },
+    { name = "torchvision", marker = "sys_platform == 'darwin'", specifier = ">=0.27,<0.28", index = "https://pypi.org/simple" },
+    { name = "torchvision", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = ">=0.27,<0.28", index = "https://pypi.org/simple" },
+    { name = "torchvision", marker = "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'cpu'", specifier = ">=0.27,<0.28" },
     { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=0.27,<0.28", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'cpu'", specifier = ">=0.27,<0.28", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.27,<0.28", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.27,<0.28" },
     { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gpu'", specifier = ">=0.27,<0.28", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "versatil", extra = "gpu" } },
-    { name = "torchvision", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'gpu') or (sys_platform != 'linux' and extra == 'gpu')", specifier = ">=0.27,<0.28" },
-    { name = "torchvision", marker = "extra == 'cpu'", specifier = ">=0.27,<0.28", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "versatil", extra = "cpu" } },
+    { name = "torchvision", marker = "sys_platform == 'linux' and extra == 'cpu'", specifier = ">=0.27,<0.28", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "versatil", extra = "cpu" } },
     { name = "tqdm", specifier = ">=4.67" },
     { name = "transformers", specifier = ">=5.9" },
     { name = "tso-robotics-sockets", specifier = ">=0.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2,19 +2,32 @@ version = 1
 revision = 3
 requires-python = ">=3.13, <3.15"
 resolution-markers = [
-    "sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
-    "sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
-    "sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
 ]
 required-markers = [
     "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
@@ -40,9 +53,9 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/60/2757c4f03a8705dbf80b1268b03881927878dca5ed07d74f733fb6c219e0/accelerate-1.11.0.tar.gz", hash = "sha256:bb1caf2597b4cd632b917b5000c591d10730bb024a79746f1ee205bba80bd229", size = 393715, upload-time = "2025-10-20T14:42:25.025Z" }
 wheels = [
@@ -285,8 +298,8 @@ name = "cattrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
 wheels = [
@@ -494,14 +507,14 @@ name = "coremltools"
 version = "9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "cattrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "attrs", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cattrs", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "protobuf", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pyaml", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "tqdm", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/e6/8cb11a246f61736e75b20488b9c3cf9c208f500c9a3f92d717dbf592348c/coremltools-9.0.tar.gz", hash = "sha256:4ff346b29c31c4b45acd19a20e0f0a1ac65180a96776e62f15bd5c46f4926687", size = 1656978, upload-time = "2025-11-10T21:51:23.855Z" }
 wheels = [
@@ -613,7 +626,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-pathfinder", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -645,34 +658,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cufft", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-curand", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform == 'win32' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 
 [[package]]
@@ -730,31 +743,31 @@ name = "executorch"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coremltools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "expecttest" },
-    { name = "flatbuffers" },
-    { name = "hydra-core" },
-    { name = "hypothesis" },
-    { name = "kgb" },
-    { name = "mpmath" },
-    { name = "numpy" },
-    { name = "omegaconf" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "parameterized" },
-    { name = "pytorch-tokenizers" },
-    { name = "pyyaml" },
-    { name = "ruamel-yaml" },
-    { name = "scikit-learn" },
-    { name = "sympy" },
-    { name = "tabulate" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions" },
+    { name = "coremltools", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "expecttest", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "flatbuffers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "hydra-core", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "hypothesis", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "kgb", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "mpmath", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "omegaconf", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "packaging", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pandas", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "parameterized", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pytorch-tokenizers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pyyaml", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "ruamel-yaml", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "scikit-learn", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "tabulate", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (python_full_version < '3.14' and platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (python_full_version < '3.14' and sys_platform != 'linux') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (python_full_version < '3.14' and platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (python_full_version < '3.14' and sys_platform != 'linux') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (python_full_version >= '3.14' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2c/9c4a5984f104d6a6cb8f41f142c4b128ae1b34852ce7ef51bd9bd5da6c75/executorch-1.3.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:08ddb9b4445e25d39bfaa21b75ef1fff321ed67e4c6d82afdb97003614aac793", size = 15619269, upload-time = "2026-05-29T17:04:21.046Z" },
@@ -915,9 +928,9 @@ version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/f4/f888e6a2f59da7e743b93532aa90a8b02bc7f828273263014b8e7bb3e1c1/geomloss-0.2.6.tar.gz", hash = "sha256:491c47085c5001b2cb6128ea541fd2d0a8808ae50e88a0798c7853c9d995faeb", size = 26752, upload-time = "2023-04-28T17:25:34.545Z" }
 
@@ -1118,7 +1131,7 @@ name = "hypothesis"
 version = "6.155.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sortedcontainers" },
+    { name = "sortedcontainers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz", hash = "sha256:d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea", size = 478291, upload-time = "2026-06-21T05:54:31.573Z" }
 wheels = [
@@ -1277,9 +1290,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -1692,6 +1705,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/66ed1fc6e38a0c0f330627ec5c5d597990d6159b6712b82af0ad2c65f06c/narwhals-2.23.0.tar.gz", hash = "sha256:13e7ff5b4bb4a2f77b907c2e4d8a76e273dfc1323a3c997440a2f9fd26aed408", size = 656209, upload-time = "2026-07-01T11:21:53.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/4e/afc8c31605cb8be1d3bb4438c4d979daa104dab6306cd2b87abe9c3a7299/narwhals-2.23.0-py3-none-any.whl", hash = "sha256:769e7b9ab102c93d8fa019f6b4cd1a657909b04a20bf6210e5a35aae06814ae9", size = 458938, upload-time = "2026-07-01T11:21:51.677Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1813,7 +1835,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1856,7 +1878,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1869,7 +1891,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1901,9 +1923,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1916,7 +1938,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2090,9 +2112,9 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -2339,7 +2361,7 @@ name = "pyaml"
 version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pyyaml", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/fb/2b9590512a9d7763620d87171c7531d5295678ce96e57393614b91da8998/pyaml-26.2.1.tar.gz", hash = "sha256:489dd82997235d4cfcf76a6287fce2f075487d77a6567c271e8d790583690c68", size = 30653, upload-time = "2026-02-06T13:49:30.769Z" }
 wheels = [
@@ -2586,9 +2608,9 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -2603,9 +2625,9 @@ name = "pytorch-tokenizers"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sentencepiece" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "sentencepiece", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "tiktoken", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "tokenizers", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/16/b7270314ff16699e54f19c8b31a86c91453a0859ae19ceadadec41548199/pytorch_tokenizers-1.3.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:2d057c3190c05808cf4954de457acce47162d8f6d5719334337e3e972b5e06c8", size = 1107320, upload-time = "2026-05-26T16:32:41.164Z" },
@@ -2874,11 +2896,26 @@ wheels = [
 name = "scikit-learn"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "scipy", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/84/5f4af978fff619706b8961accac84780a6d298d82a8873446f72edb4ead0/scikit_learn-1.7.1.tar.gz", hash = "sha256:24b3f1e976a4665aa74ee0fcaac2b8fccc6ae77c8e07ab25da3ba6d3292b9802", size = 7190445, upload-time = "2025-07-18T08:01:54.5Z" }
 wheels = [
@@ -2892,6 +2929,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/80/abe18fe471af9f1d181904203d62697998b27d9b62124cd281d740ded2f9/scikit_learn-1.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1f812729e38c8cb37f760dce71a9b83ccfb04f59b3dca7c6079dcdc60544fa9e", size = 9532052, upload-time = "2025-07-18T08:01:48.676Z" },
     { url = "https://files.pythonhosted.org/packages/14/82/b21aa1e0c4cee7e74864d3a5a721ab8fcae5ca55033cb6263dca297ed35b/scikit_learn-1.7.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88e1a20131cf741b84b89567e1717f27a2ced228e0f29103426102bc2e3b8ef7", size = 9361575, upload-time = "2025-07-18T08:01:50.639Z" },
     { url = "https://files.pythonhosted.org/packages/f2/20/f4777fcd5627dc6695fa6b92179d0edb7a3ac1b91bcd9a1c7f64fa7ade23/scikit_learn-1.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b1bd1d919210b6a10b7554b717c9000b5485aa95a1d0f177ae0d7ee8ec750da5", size = 9277310, upload-time = "2025-07-18T08:01:52.547Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "narwhals", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "scipy", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
 ]
 
 [[package]]
@@ -3193,8 +3278,8 @@ name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex" },
-    { name = "requests" },
+    { name = "regex", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "requests", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
 wheels = [
@@ -3236,12 +3321,12 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
 wheels = [
@@ -3279,26 +3364,39 @@ name = "torch"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "sys_platform == 'darwin'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "filelock", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "fsspec", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "jinja2", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "networkx", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "setuptools", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "triton", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-bindings", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "fsspec", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "jinja2", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "networkx", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "setuptools", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "sympy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "triton", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
@@ -3324,18 +3422,19 @@ name = "torch"
 version = "2.12.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "fsspec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "networkx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "setuptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "fsspec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "networkx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "setuptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:5e0da19e1c3bfdc9b92638c552579eac678354485d61fc8921b0461fd6c40449", upload-time = "2026-05-12T23:17:05Z" },
@@ -3362,26 +3461,25 @@ name = "torch"
 version = "2.12.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "filelock", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "fsspec", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "jinja2", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "networkx", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cublas", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "setuptools", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "sympy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "triton", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "typing-extensions", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "fsspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "networkx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cudnn-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nccl-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "setuptools", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "sympy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bf5f067d3a4d713b75ccd6a0141f8133c7495a016b917ce6dcec1492e3da98b0", upload-time = "2026-05-12T23:51:35Z" },
@@ -3403,9 +3501,22 @@ name = "torchao"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "sys_platform == 'darwin'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/fe/a4036a8e80fa800c92dbcbf75f541cd4c106248b6b579db6dab1800f616a/torchao-0.17.0-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87a418ce0ec064a821ceab83c921b501acef0ce9a6ccd1be358fcd16c3ae8c58", size = 3206172, upload-time = "2026-03-30T22:25:52.974Z" },
@@ -3417,9 +3528,10 @@ name = "torchao"
 version = "0.17.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cpu/torchao-0.17.0%2Bcpu-py3-none-any.whl", hash = "sha256:6c0ce8b506c72be4efb1f0c6fd1679cb58145efebb20d51ac1adf7a7b3ebb872", upload-time = "2026-03-30T20:39:35Z" },
@@ -3430,9 +3542,8 @@ name = "torchao"
 version = "0.17.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cu130/torchao-0.17.0%2Bcu130-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79ddf24c7e846ac9fb856f709394c4f60932994c2a125708d39833c12ea41d87", upload-time = "2026-03-30T20:39:51Z" },
@@ -3446,9 +3557,9 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765, upload-time = "2026-03-09T17:41:22.443Z" }
 wheels = [
@@ -3460,14 +3571,27 @@ name = "torchvision"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "sys_platform == 'darwin'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
@@ -3493,14 +3617,15 @@ name = "torchvision"
 version = "0.27.0+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pillow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:69093b64b2762c43df17be2db2be163029963d90bc3f1801500fdeb723e54833", upload-time = "2026-05-12T16:20:36Z" },
@@ -3522,14 +3647,13 @@ name = "torchvision"
 version = "0.27.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
-    "sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "pillow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:da81245777c47f6dfd60e02f510d9778fb7f6e23119e2fc1ea1bb06777aae338", upload-time = "2026-05-12T16:20:44Z" },
@@ -3691,21 +3815,22 @@ dependencies = [
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "scikit-learn" },
+    { name = "scikit-learn", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "scipy" },
     { name = "seaborn" },
     { name = "termcolor" },
     { name = "threadpoolctl" },
     { name = "timm" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform == 'darwin' or (sys_platform != 'linux' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-8-versatil-cpu') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra != 'extra-8-versatil-cpu' and extra != 'extra-8-versatil-gpu') or sys_platform != 'linux'" },
+    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "tso-robotics-sockets" },
@@ -3716,12 +3841,12 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-8-versatil-cpu') or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 docs = [
     { name = "mkdocs-gen-files" },
@@ -3733,12 +3858,15 @@ executorch = [
     { name = "executorch", marker = "python_full_version < '3.14' or (extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 gpu = [
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchao", version = "0.17.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchao", version = "0.17.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine == 'aarch64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-versatil-gpu') or (platform_machine != 'x86_64' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu') or (sys_platform != 'linux' and extra == 'extra-8-versatil-cpu' and extra == 'extra-8-versatil-gpu')" },
 ]
 
 [package.dev-dependencies]
@@ -3781,7 +3909,8 @@ requires-dist = [
     { name = "pytorch-lightning", specifier = ">=2.6" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "safetensors", specifier = ">=0.6" },
-    { name = "scikit-learn", specifier = ">=1.7.1" },
+    { name = "scikit-learn", marker = "python_full_version < '3.14'", specifier = ">=1.7.1" },
+    { name = "scikit-learn", marker = "python_full_version >= '3.14'", specifier = ">=1.7.2" },
     { name = "scipy", specifier = ">=1.16" },
     { name = "seaborn", specifier = ">=0.13" },
     { name = "termcolor", specifier = ">=3.2" },


### PR DESCRIPTION
Adds macOS arm64 as a supported platform for CPU workflows. CPU compute only. MPS (Apple GPU) is not wired up and stays unsupported for now; device selection defaults to CPU on Macs. geomloss/pykeops (MMD and Sinkhorn losses) JIT-compile C++ on first use and need Xcode Command Line Tools.
