### PR TITLE
Make Codecov statuses informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,13 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        informational: true
     patch:
       default:
-        target: 90%
-        threshold: 1%
-
-comment:
-  layout: "condensed_header, diff, files"
-  require_changes: true
+        informational: true


### PR DESCRIPTION
Keeps Codecov fully active but makes its `project`/`patch` commit statuses informational so they can never paint main red