### PR TITLE
Accept Lightning's canonical precision strings in PrecisionType

### DIFF
--- a/src/versatil/training/constants.py
+++ b/src/versatil/training/constants.py
@@ -23,6 +23,21 @@ class PrecisionType(StrEnum):
     BF16_TRUE = "bf16-true"  # Pure bfloat16 (not recommended)
     FP64 = "64"  # Double precision (rarely needed)
 
+    @classmethod
+    def _missing_(cls, value: str) -> "PrecisionType | None":
+        """Accept Lightning's canonical precision strings.
+
+        ``Trainer.precision`` normalizes ``32`` to ``"32-true"`` and ``64``
+        to ``"64-true"``; map those back onto the enum members.
+        """
+        aliases = {
+            "32-true": cls.FP32,
+            "64-true": cls.FP64,
+            "16": cls.FP16_MIXED,
+            "bf16": cls.BF16_MIXED,
+        }
+        return aliases.get(value)
+
     def get_model_dtype(self) -> torch.dtype:
         """Get the dtype to convert model parameters to for this precision type.
 

--- a/tests/training/test_constants.py
+++ b/tests/training/test_constants.py
@@ -27,6 +27,32 @@ class TestPrecisionTypeIsMixed:
         assert precision.is_mixed() is expected
 
 
+class TestPrecisionTypeLightningAliases:
+    @pytest.mark.parametrize(
+        "lightning_precision, expected",
+        [
+            ("32-true", PrecisionType.FP32),
+            ("64-true", PrecisionType.FP64),
+            ("16", PrecisionType.FP16_MIXED),
+            ("bf16", PrecisionType.BF16_MIXED),
+            ("bf16-mixed", PrecisionType.BF16_MIXED),
+        ],
+    )
+    def test_trainer_precision_strings_resolve(
+        self,
+        lightning_precision: str,
+        expected: PrecisionType,
+    ):
+        assert PrecisionType(lightning_precision) is expected
+
+    def test_unknown_precision_still_raises(self):
+        with pytest.raises(
+            ValueError,
+            match="'transformer-engine' is not a valid PrecisionType",
+        ):
+            PrecisionType("transformer-engine")
+
+
 class TestPrecisionTypeAutocast:
     @pytest.mark.parametrize(
         "precision, expected_enabled",


### PR DESCRIPTION
the callbacks introduced in #5 derive their autocast context from `trainer.precision`, and Lightning normalizes `precision=32` to the string `"32-true"` (and 64 to "64-true"), which `PrecisionType` did not recognize. The enum now resolves Lightning's canonical aliases (`32-true`, `64-true`, `16`, `bf16`) onto the existing members via `_missing_`, so every call site handles them; unknown strings still raise.
