### PR TITLE
Update MoDE-ACT policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Mixed-precision training keeps trainable parameters in float32 storage, so optimizer updates no longer round away in bf16. This unblocks autoregressive OpenVLA LoRA fine-tuning, whose adapters previously never left their initialization.
 - Forward passes outside the Lightning loop (synthetic rollout evaluation, prior target standardization, explainability attribution, encoder shape probing) run under the same autocast as training instead of crashing on mixed-precision policies.
+- MoDE-ACT mixture heads initialize from aligned demonstrated action chunks with
+  per-timestep component biases and horizon-tempered log-variance, preserving
+  temporal structure and cross-action mode correspondence.
 
 ### Added
 - The publish workflow verifies each release by installing it from PyPI in clean pip and uv environments and running a training smoke test.
@@ -17,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - OpenVLA and OpenVLA-OFT presets train LoRA with the recipe learning rate of 5e-4.
 - main carries a `.dev` version between releases so source installs are distinguishable from PyPI releases.
+- Gaussian mixture NLL training defaults to fixed variance with sigma 0.5.
+  MoDE-ACT rejects stochastic Gaussian sampling in that mode because its
+  predicted log-variance is not trained.
 
 ## [0.4.1] - 2026-07-05
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Mixed-precision training keeps trainable parameters in float32 storage, so optimizer updates no longer round away in bf16. This unblocks autoregressive OpenVLA LoRA fine-tuning, whose adapters previously never left their initialization.
+- Forward passes outside the Lightning loop (synthetic rollout evaluation, prior target standardization, explainability attribution, encoder shape probing) run under the same autocast as training instead of crashing on mixed-precision policies.
+- MoDE-ACT mixture heads initialize from aligned demonstrated action chunks with
+  per-timestep component biases and horizon-tempered log-variance, preserving
+  temporal structure and cross-action mode correspondence.
+
+### Added
+- The publish workflow verifies each release by installing it from PyPI in clean pip and uv environments and running a training smoke test.
+
+### Changed
+- OpenVLA and OpenVLA-OFT presets train LoRA with the recipe learning rate of 5e-4.
+- main carries a `.dev` version between releases so source installs are distinguishable from PyPI releases.
+- Gaussian mixture NLL training defaults to fixed variance with sigma 0.5.
+  MoDE-ACT rejects stochastic Gaussian sampling in that mode because its
+  predicted log-variance is not trained.
+
+## [0.4.1] - 2026-07-05
+
+### Fixed
+- Ship the SIL OFL license text with the bundled Roboto Serif font.
+- The PyPI project page renders the logo correctly.
+
+### Added
+- `CITATION.cff` and a `CONTRIBUTING.md` contributor guide.
+
+### Changed
+- README rewritten and documentation refreshed for the public release.
+
 ## [0.4.0] - 2026-07-05
 
 ### Added

--- a/src/versatil/configs/data/dataloader.py
+++ b/src/versatil/configs/data/dataloader.py
@@ -55,10 +55,11 @@ class DataLoaderConfig:
         val_ratio: : Ratio of dataset episodes to use for validation.
         total_ratio: : Ratio of total dataset episodes to use (for ablation studies on
             varying dataset sizes).
-        action_sample_size: : Number of action rows to stash on the normalizer per
-            action key for downstream : data-aware initialization (e.g. mixture-density
-            head k-means++). Set to 0 to : disable. Memory cost per action key is
-            ``action_sample_size * action_dim * : bytes_per_element``.
+        action_sample_size: : Number of action chunk windows to stash on the
+            normalizer per action key : for downstream data-aware initialization
+            (e.g. chunk-space mixture-density). Set to 0 to disable.
+            Memory cost per action key is : ``action_sample_size *
+            prediction_horizon * action_dim * bytes_per_element``.
     """
 
     preload_data_in_memory: bool = False  # Whether to preload the entire zarr into RAM, speeds up training considerably but works only for small datasets.
@@ -105,8 +106,6 @@ class DataLoaderConfig:
     val_ratio: float = 0.1
     #: Ratio of total dataset episodes to use (for ablation studies on varying dataset sizes).
     total_ratio: float = 1.0
-    #: Number of action rows to stash on the normalizer per action key for downstream
-    #: data-aware initialization (e.g. mixture-density head k-means++). Set to 0 to
-    #: disable. Memory cost per action key is ``action_sample_size * action_dim *
-    #: bytes_per_element``.
+    #: Number of action chunk windows to stash on the normalizer per action key for
+    #: downstream data-aware initialization
     action_sample_size: int = 2048

--- a/src/versatil/configs/loss.py
+++ b/src/versatil/configs/loss.py
@@ -394,8 +394,10 @@ class GaussianMixtureNLLossConfig(BaseLossConfig):
         weight: Overall loss weight.
         per_key_weights: Optional per-key weights.
         learned_variance: If True, expects {action_key}_mean and {action_key}_logvar. If
-            False, expects {action_key} (stacked means) and uses sigmas.
+            False, expects {action_key} (stacked means) and uses sigmas. Defaults to
+            False.
         sigmas: Fixed stddev per action key (only used when learned_variance=False).
+            The loss defaults missing keys to 0.5.
         min_variance: Minimum variance for numerical stability (learned_variance=True).
     """
 
@@ -403,7 +405,7 @@ class GaussianMixtureNLLossConfig(BaseLossConfig):
     action_keys: list[str] = MISSING
     weight: float = 1.0
     per_key_weights: dict[str, float] | None = None
-    learned_variance: bool = True
+    learned_variance: bool = False
     sigmas: dict[str, float] | None = None
     min_variance: float = 1e-4
 

--- a/src/versatil/data/episodic_dataset.py
+++ b/src/versatil/data/episodic_dataset.py
@@ -301,8 +301,9 @@ class EpisodicDataset(data.Dataset):
             clamp_kinematics_range: Whether to clamp std/range to minimum values.
             min_kinematics_std: Minimum std for Gaussian mode when clamp_kinematics_range=True.
             min_kinematics_range: Minimum range for MinMax mode when clamp_kinematics_range=True.
-            action_sample_size: Number of action rows to stash on the normalizer per
-                action key for downstream data-aware initialization. Set to 0 to disable.
+            action_sample_size: Number of action chunk windows to stash on the
+                normalizer per action key for downstream data-aware
+                initialization. Set to 0 to disable.
 
         Returns:
             Tuple of (normalizer, tokenizer) where tokenizer is None if not configured

--- a/src/versatil/data/normalization/normalizer.py
+++ b/src/versatil/data/normalization/normalizer.py
@@ -34,7 +34,6 @@ class LinearNormalizer(DictOfTensorMixin):
         clamp_range: bool = True,
         min_std: float = 2e-2,
         min_range: float = 4e-2,
-        sample_size: int | dict[str, int] = 0,
     ):
         """Fit normalization parameters to data.
 
@@ -51,18 +50,9 @@ class LinearNormalizer(DictOfTensorMixin):
             clamp_range: Whether to clamp std/range to minimum values.
             min_std: Minimum std value when clamp_range=True and mode='gaussian'.
             min_range: Minimum range value when clamp_range=True and mode='min_max'.
-            sample_size: Number of data rows to store as an empirical sample under
-                each key. Pass an int to use the same budget for every key, or a
-                ``{key: size}`` dict to store samples only for selected keys
-                (missing keys default to 0 = no sample stored).
         """
         if isinstance(data, dict):
             for key, value in data.items():
-                per_key_size = (
-                    sample_size.get(key, 0)
-                    if isinstance(sample_size, dict)
-                    else sample_size
-                )
                 self.params_dict[key] = _fit(
                     value,
                     last_n_dims=last_n_dims,
@@ -76,14 +66,8 @@ class LinearNormalizer(DictOfTensorMixin):
                     clamp_range=clamp_range,
                     min_std=min_std,
                     min_range=min_range,
-                    sample_size=per_key_size,
                 )
         else:
-            single_size = (
-                sample_size.get("_default", 0)
-                if isinstance(sample_size, dict)
-                else sample_size
-            )
             self.params_dict["_default"] = _fit(
                 data,
                 last_n_dims=last_n_dims,
@@ -97,7 +81,6 @@ class LinearNormalizer(DictOfTensorMixin):
                 clamp_range=clamp_range,
                 min_std=min_std,
                 min_range=min_range,
-                sample_size=single_size,
             )
 
     def __call__(self, x: dict | torch.Tensor | np.ndarray) -> dict | torch.Tensor:
@@ -210,6 +193,33 @@ class LinearNormalizer(DictOfTensorMixin):
                 result[key] = value["input_stats"]
         return result
 
+    def set_sample_chunks(self, key: str, chunks: torch.Tensor | np.ndarray) -> None:
+        """Attach a raw ``(N, H, D)`` action-chunk subsample to a fitted key.
+
+        Chunk subsamples enable chunk-level data-aware initialization (e.g.
+        trajectory-space k-means++ for mixture-density heads).
+
+        Args:
+            key: Fitted parameter key to attach the subsample to.
+            chunks: ``(N, H, D)`` array of raw action windows, where ``H`` is
+                the prediction horizon and ``D`` the per-step action dimension.
+
+        Raises:
+            KeyError: If the key has not been fitted.
+        """
+        if key not in self.params_dict:
+            raise KeyError(
+                f"Cannot attach sample chunks to unfitted key '{key}'. "
+                f"Fitted keys: {list(self.params_dict.keys())}."
+            )
+        if isinstance(chunks, np.ndarray):
+            chunks = torch.from_numpy(chunks)
+        dtype = self.params_dict[key]["scale"].dtype
+        parameter = nn.Parameter(
+            chunks.clone().detach().to(dtype=dtype), requires_grad=False
+        )
+        self.params_dict[key]["sample_chunks"] = parameter
+
     def get_output_stats(self, key: str = "_default") -> dict:
         """Get normalized output statistics for a specific key.
 
@@ -256,7 +266,6 @@ class SingleFieldLinearNormalizer(DictOfTensorMixin):
         clamp_range: bool = True,
         min_std: float = 2e-2,
         min_range: float = 4e-2,
-        sample_size: int = 0,
     ):
         """Fit scale and offset for one field from data statistics."""
         self.params_dict = _fit(
@@ -272,7 +281,6 @@ class SingleFieldLinearNormalizer(DictOfTensorMixin):
             clamp_range=clamp_range,
             min_std=min_std,
             min_range=min_range,
-            sample_size=sample_size,
         )
 
     @classmethod
@@ -388,21 +396,22 @@ class SingleFieldLinearNormalizer(DictOfTensorMixin):
             result["std"] = torch.abs(scale) * input_stats["std"]
         return result
 
-    def get_input_sample(self) -> torch.Tensor | None:
-        """Return the raw subsample stored at fit time, or ``None`` if absent.
+    def get_input_sample_chunks(self) -> torch.Tensor | None:
+        """Return the raw ``(N, H, D)`` chunk subsample, or ``None`` if absent.
 
-        Present only when ``fit(..., sample_size>0)`` was used.
+        Present only when ``LinearNormalizer.set_sample_chunks`` was called for
+        this key after fitting.
         """
-        if "sample" in self.params_dict:
-            return self.params_dict["sample"]
+        if "sample_chunks" in self.params_dict:
+            return self.params_dict["sample_chunks"]
         return None
 
-    def get_output_sample(self) -> torch.Tensor | None:
-        """Return the stored subsample in normalized output space, or ``None``."""
-        raw_sample = self.get_input_sample()
-        if raw_sample is None:
+    def get_output_sample_chunks(self) -> torch.Tensor | None:
+        """Return the stored chunk subsample in normalized output space, or ``None``."""
+        raw_chunks = self.get_input_sample_chunks()
+        if raw_chunks is None:
             return None
-        return self.normalize(raw_sample)
+        return self.normalize(raw_chunks)
 
     def __call__(self, x: torch.Tensor | np.ndarray) -> torch.Tensor:
         return self.normalize(x)
@@ -421,7 +430,6 @@ def _fit(
     clamp_range: bool = True,
     min_std: float = 2e-2,
     min_range: float = 4e-2,
-    sample_size: int = 0,
 ) -> nn.ParameterDict:
     """Fit normalization parameters to data.
 
@@ -438,15 +446,9 @@ def _fit(
         clamp_range: Whether to clamp std/range to minimum values.
         min_std: Minimum std value when clamp_range=True and mode='gaussian'.
         min_range: Minimum range value when clamp_range=True and mode='min_max'.
-        sample_size: If > 0, store a random subsample of the flattened input data
-            under key ``sample`` in the returned ParameterDict. The sample
-            preserves the empirical distribution of the data and can be used
-            by downstream consumers that need density information, not just
-            marginal statistics (e.g. data-aware GMM init). The subsample is
-            drawn without replacement and capped at ``min(sample_size, N)``.
 
     Returns:
-        ParameterDict with scale, offset, input_stats, and optionally sample.
+        ParameterDict with scale, offset, and input_stats.
     """
     valid_modes = [mode_type.value for mode_type in KinematicsNormalizationType]
     if mode not in valid_modes:
@@ -532,11 +534,6 @@ def _fit(
             ),
         }
     )
-    if sample_size > 0:
-        n_rows = tensor_data.shape[0]
-        take = min(sample_size, n_rows)
-        indices = torch.randperm(n_rows, device=tensor_data.device)[:take]
-        parameters["sample"] = tensor_data[indices].clone().detach()
     for parameter in parameters.parameters():
         parameter.requires_grad_(False)
     return parameters

--- a/src/versatil/data/processing/transform_builder.py
+++ b/src/versatil/data/processing/transform_builder.py
@@ -134,11 +134,13 @@ class TransformBuilder:
             clamp_kinematics_range: Whether to clamp std/range to minimum values.
             min_kinematics_std: Minimum std for Gaussian mode when clamp_kinematics_range=True.
             min_kinematics_range: Minimum range for MinMax mode when clamp_kinematics_range=True.
-            action_sample_size: Number of action rows to stash alongside each action
-                key's normalizer for downstream data-aware initialization (e.g.
-                mixture-density head k-means++). Set to 0 to disable. Memory cost
-                per action key is ``action_sample_size * action_dim * bytes_per_element``
-                (four bytes for float32, eight for float64).
+            action_sample_size: Number of action chunk windows (length
+                ``prediction_horizon``, aligned across keys) to stash on the
+                normalizer per action key for downstream data-aware
+                initialization (e.g. chunk-space mixture-density).
+                Set to 0 to disable. Memory cost per action key is
+                ``action_sample_size * prediction_horizon * action_dim *
+                bytes_per_element``.
             episode_selection_mask: Optional boolean mask over episodes.
                 Statistics, tokenizers, and denoising thresholds are fitted
                 only on selected episodes (the training split), keeping
@@ -253,6 +255,22 @@ class TransformBuilder:
             action_meta=action_meta,
             device=device,
         )
+        chunk_action_keys = [
+            key for key, meta in action_meta.items() if meta.needs_normalization
+        ]
+        chunk_action_data = (
+            action_source_data
+            if self.action_processor.action_space.has_only_precomputed_actions
+            else action_data
+        )
+        self._stash_action_chunk_samples(
+            normalizer=normalizer,
+            action_data=chunk_action_data,
+            action_keys=chunk_action_keys,
+            requires_next_observation=(
+                not self.action_processor.action_space.has_only_precomputed_actions
+            ),
+        )
         tokenizer = None
         if self.tokenization_config and (
             self.tokenization_config.tokenize_observations
@@ -273,6 +291,78 @@ class TransformBuilder:
                 device=device,
             )
         return normalizer, tokenizer
+
+    def _sample_chunk_start_indices(
+        self,
+        row_count: int,
+        requires_next_observation: bool = True,
+    ) -> np.ndarray:
+        """Sample window start rows for action-chunk subsampling.
+
+        Windows have length ``prediction_horizon`` and must lie fully inside a
+        single selected episode. On-the-fly actions exclude each episode's
+        final row because they require the next observation.
+
+        Args:
+            row_count: Number of rows in the step-aligned action arrays.
+            requires_next_observation: Whether each action row uses the next
+                observation and therefore cannot start from episode-final rows.
+
+        Returns:
+            ``(N,)`` array of start rows, ``N <= action_sample_size``.
+        """
+        horizon = self.prediction_horizon
+        terminal_offset = 1 if requires_next_observation else 0
+        valid_starts = []
+        episode_start = 0
+        for episode_index, episode_end in enumerate(self.episode_ends):
+            episode_end = min(int(episode_end), row_count + terminal_offset)
+            if self._is_episode_selected(episode_index=episode_index):
+                last_start = episode_end - terminal_offset - horizon
+                if last_start >= episode_start:
+                    valid_starts.append(np.arange(episode_start, last_start + 1))
+            episode_start = int(episode_end)
+        if not valid_starts:
+            return np.empty(0, dtype=np.int64)
+        all_starts = np.concatenate(valid_starts)
+        take = min(self.action_sample_size, all_starts.shape[0])
+        return self._random_generator.choice(all_starts, size=take, replace=False)
+
+    def _stash_action_chunk_samples(
+        self,
+        normalizer: LinearNormalizer,
+        action_data: dict[str, np.ndarray],
+        action_keys: list[str],
+        requires_next_observation: bool = True,
+    ) -> None:
+        """Store aligned ``(N, H, D)`` chunk subsamples on the fitted normalizer.
+
+        The same window starts are used for every action key, so component
+        indices stay in correspondence across keys during downstream joint
+        chunk-space initialization.
+
+        Args:
+            normalizer: Fitted normalizer to attach the subsamples to.
+            action_data: Step-aligned per-key action arrays covering all rows.
+            action_keys: Normalized action keys to stash chunks for.
+            requires_next_observation: Whether action windows must exclude the
+                episode-final rows used only as next observations.
+        """
+        if self.action_sample_size <= 0 or not action_keys:
+            return
+        row_count = min(action_data[key].shape[0] for key in action_keys)
+        start_indices = self._sample_chunk_start_indices(
+            row_count=row_count,
+            requires_next_observation=requires_next_observation,
+        )
+        if start_indices.shape[0] == 0:
+            return
+        window_indices = start_indices[:, None] + np.arange(
+            self.prediction_horizon
+        )  # (N, H)
+        for key in action_keys:
+            chunks = action_data[key][window_indices]  # (N, H, D)
+            normalizer.set_sample_chunks(key=key, chunks=chunks)
 
     def compute_proprioceptive_denoising_thresholds(
         self,
@@ -328,20 +418,13 @@ class TransformBuilder:
                     array=self.replay_buffer[key][:]
                 )
 
-        action_normalization_keys: set[str] = set()
         for key, meta in action_meta.items():
             if meta.needs_normalization:
                 data_to_normalize[key] = action_data[key]
-                action_normalization_keys.add(key)
         if self.kinematics_winsorize_quantiles:
             data_to_normalize = self._apply_winsorization(
                 data_to_normalize, self.kinematics_winsorize_quantiles
             )
-        sample_sizes = (
-            dict.fromkeys(action_normalization_keys, self.action_sample_size)
-            if self.action_sample_size > 0
-            else 0
-        )
         normalizer.fit(
             data=data_to_normalize,
             last_n_dims=1,
@@ -351,7 +434,6 @@ class TransformBuilder:
             clamp_range=self.clamp_kinematics_range,
             min_std=self.min_kinematics_std,
             min_range=self.min_kinematics_range,
-            sample_size=sample_sizes,
         )
         self._setup_image_normalizers(normalizer, device, winsorize_depth)
         self._log_normalized_proprio_stats(normalizer, data_to_normalize)

--- a/src/versatil/hydra_configs/policy/loss/gaussian_mixture_nll_synthetic.yaml
+++ b/src/versatil/hydra_configs/policy/loss/gaussian_mixture_nll_synthetic.yaml
@@ -16,7 +16,9 @@ loss_modules:
           action_keys:
             - ${proprio_key:SYNTHETIC_POSITION_ACTION}
           weight: 1.0
-          learned_variance: true
+          learned_variance: false
+          sigmas:
+            ${proprio_key:SYNTHETIC_POSITION_ACTION}: 0.5
 
         trajectory_length:
           weight: 0.0

--- a/src/versatil/metrics/losses/mixture.py
+++ b/src/versatil/metrics/losses/mixture.py
@@ -12,6 +12,8 @@ from versatil.metrics.constants import MetricKey
 from versatil.metrics.losses.gripper import resolve_gripper_metadata
 from versatil.models.decoding.constants import DecoderOutputKey
 
+DEFAULT_FIXED_SIGMA = 0.5
+
 
 def _aggregate_mixture_nll(
     log_component: torch.Tensor,
@@ -89,7 +91,7 @@ class GaussianMixtureNLLoss(ScalarWeightedLoss):
         action_keys: list[str],
         weight: float = 1.0,
         per_key_weights: dict[str, float] | None = None,
-        learned_variance: bool = True,
+        learned_variance: bool = False,
         sigmas: dict[str, float] | None = None,
         min_variance: float = 1e-4,
     ):
@@ -101,7 +103,8 @@ class GaussianMixtureNLLoss(ScalarWeightedLoss):
             per_key_weights: Optional per-key weights.
             learned_variance: If True, expects {action_key}_mean and {action_key}_logvar.
                 If False, expects {action_key} (stacked means) and uses sigmas.
-            sigmas: Fixed stddev per action key (only used when learned_variance=False).
+            sigmas: Fixed stddev per action key (only used when
+                ``learned_variance=False``). Defaults to 0.5 for every key.
             min_variance: Minimum variance for numerical stability (learned_variance=True).
         """
         super().__init__()
@@ -111,7 +114,7 @@ class GaussianMixtureNLLoss(ScalarWeightedLoss):
         self.learned_variance = learned_variance
         self.min_variance = min_variance
         if not learned_variance:
-            self.sigmas = sigmas or dict.fromkeys(action_keys, 0.5)
+            self.sigmas = sigmas or dict.fromkeys(action_keys, DEFAULT_FIXED_SIGMA)
 
     def get_required_keys(self) -> set[str]:
         """Get required target keys."""
@@ -152,7 +155,7 @@ class GaussianMixtureNLLoss(ScalarWeightedLoss):
                     target, means, logvars
                 )
             else:
-                sigma = self.sigmas.get(action_key, 0.5)
+                sigma = self.sigmas.get(action_key, DEFAULT_FIXED_SIGMA)
                 log_component = self._compute_fixed_variance_log_pdf(
                     target, means, sigma
                 )

--- a/src/versatil/models/decoding/action_heads/gaussian.py
+++ b/src/versatil/models/decoding/action_heads/gaussian.py
@@ -27,9 +27,34 @@ class GaussianHead(BaseActionHead):
             max_logvar: Maximum value for logvar clamping.
         """
         super().__init__(input_dimension=input_dimension, blocks=blocks)
-        self.min_logvar = min_logvar
-        self.max_logvar = max_logvar
+        self.register_buffer(
+            "_min_logvar",
+            torch.tensor(min_logvar, dtype=torch.float32),
+        )
+        self.register_buffer(
+            "_max_logvar",
+            torch.tensor(max_logvar, dtype=torch.float32),
+        )
         self._logvar_proj: nn.Linear | None = None
+        self.temporal_bias: nn.Parameter | None = None
+
+    @property
+    def min_logvar(self) -> float:
+        """Return the lower log-variance clamp."""
+        return float(self._min_logvar.item())
+
+    @min_logvar.setter
+    def min_logvar(self, value: float) -> None:
+        self._min_logvar.fill_(value)
+
+    @property
+    def max_logvar(self) -> float:
+        """Return the upper log-variance clamp."""
+        return float(self._max_logvar.item())
+
+    @max_logvar.setter
+    def max_logvar(self, value: float) -> None:
+        self._max_logvar.fill_(value)
 
     def set_output_dim(self, dim: int) -> None:
         """Create both mean and logvar projections.
@@ -40,6 +65,22 @@ class GaussianHead(BaseActionHead):
         super().set_output_dim(dim)
         hidden_dimension = self._get_hidden_dim()
         self._logvar_proj = nn.Linear(hidden_dimension, dim)
+
+    def enable_temporal_bias(self, horizon: int) -> None:
+        """Create a zero-initialized per-timestep bias added to the mean.
+
+        Gives each timestep an independent mean offset, so a bias-only
+        initialization can hold a full trajectory instead of a constant.
+
+        Args:
+            horizon: Number of timesteps the head is applied to per forward.
+
+        Raises:
+            RuntimeError: If set_output_dim() has not been called yet.
+        """
+        if self._output_dim is None:
+            raise RuntimeError("output_dim not set. Call set_output_dim() first.")
+        self.temporal_bias = nn.Parameter(torch.zeros(horizon, self._output_dim))
 
     def forward(self, action_embedding: torch.Tensor) -> dict[str, torch.Tensor]:
         """Forward pass returning mean and clamped logvar.
@@ -54,8 +95,11 @@ class GaussianHead(BaseActionHead):
             raise RuntimeError("output_dim not set. Call set_output_dim() first.")
         action_embedding = self._apply_blocks(action_embedding)
         mean = self.output_proj(action_embedding)
+        if self.temporal_bias is not None:
+            mean = mean + self.temporal_bias
         logvar = self._logvar_proj(action_embedding)
-        logvar = logvar.clamp(min=self.min_logvar, max=self.max_logvar)
+        logvar = torch.maximum(logvar, self._min_logvar.to(logvar))
+        logvar = torch.minimum(logvar, self._max_logvar.to(logvar))
         return {
             DecoderOutputKey.MEAN.value: mean,
             DecoderOutputKey.LOGVAR.value: logvar,

--- a/src/versatil/models/decoding/decoders/factory/mode_act.py
+++ b/src/versatil/models/decoding/decoders/factory/mode_act.py
@@ -5,6 +5,7 @@ multiple mixture components for each action, enabling multi-modal action distrib
 """
 
 import copy
+import math
 
 import torch
 import torch.nn.functional as F
@@ -200,7 +201,12 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
         )
 
     def _build_mixture_heads(self) -> None:
-        """Clone each action head K times for mixture components."""
+        """Clone each action head K times for mixture components.
+
+        Note:
+            Gaussian clones get a per-timestep temporal bias so a bias-only
+            initialization can hold a full trajectory per component.
+        """
         self.mixture_heads: nn.ModuleDict = nn.ModuleDict()
         for action_key, head in self.action_heads.items():
             cloned_heads = []
@@ -209,6 +215,8 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
                 for module in cloned_head.modules():
                     if hasattr(module, "reset_parameters"):
                         module.reset_parameters()
+                if isinstance(cloned_head, GaussianHead):
+                    cloned_head.enable_temporal_bias(horizon=self.prediction_horizon)
                 cloned_heads.append(cloned_head)
             self.mixture_heads[action_key] = nn.ModuleList(cloned_heads)
 
@@ -249,24 +257,243 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
     def set_normalizer(self, normalizer: LinearNormalizer) -> None:
         """Set normalizer and initialize GMM components from output statistics.
 
+        Note:
+            Initialization always runs in chunk space; the strategy only
+            selects how the trajectory centers are spread (k-means++ over the
+            candidate chunks or uniform envelope interpolation). Candidates
+            are the demonstrated chunk subsamples carried by the normalizer,
+            or constant trajectories sampled uniformly from the normalized
+            action range when no subsample is available.
+
         Args:
             normalizer: Normalizer with fitted statistics.
         """
         super().set_normalizer(normalizer)
         self._initialize_gating_network()
-        for action_key in self.action_keys:
-            if action_key not in normalizer.params_dict:
-                continue
-            field_normalizer = normalizer[action_key]
-            output_stats = field_normalizer.get_output_stats()
-            candidate_sample = field_normalizer.get_output_sample()
-            base_head = self.action_heads[action_key]
-            if isinstance(base_head, GaussianHead):
-                self._initialize_gaussian_mixture(
-                    action_key=action_key,
-                    output_stats=output_stats,
-                    candidate_sample=candidate_sample,
+        gaussian_keys = [
+            action_key
+            for action_key in self.action_keys
+            if action_key in normalizer.params_dict
+            and isinstance(self.action_heads[action_key], GaussianHead)
+        ]
+        if not gaussian_keys:
+            return
+        chunk_samples = self._collect_chunk_samples(
+            normalizer=normalizer, action_keys=gaussian_keys
+        )
+        if chunk_samples is None:
+            chunk_samples = self._constant_chunk_candidates(
+                normalizer=normalizer, action_keys=gaussian_keys
+            )
+        self._initialize_gaussian_mixture(
+            normalizer=normalizer,
+            action_keys=gaussian_keys,
+            chunk_samples=chunk_samples,
+        )
+
+    def _constant_chunk_candidates(
+        self,
+        normalizer: LinearNormalizer,
+        action_keys: list[str],
+    ) -> dict[str, torch.Tensor]:
+        """Fallback to constant-trajectory candidates when no chunk subsample exists.
+
+        Single actions sampled uniformly from the normalized range are
+        broadcast over the prediction horizon, so a per-step candidate is
+        simply a chunk of constant value. Covers only the bounding box of the
+        action distribution, not its modal structure.
+
+        Args:
+            normalizer: Normalizer with fitted statistics.
+            action_keys: Gaussian action keys to build candidates for.
+
+        Returns:
+            Dict of ``(N, H, D)`` constant candidate chunks per key.
+        """
+        candidates: dict[str, torch.Tensor] = {}
+        for action_key in action_keys:
+            stats = normalizer.get_output_stats(key=action_key)
+            single_actions = self._sample_uniform_candidates(
+                data_min=stats["min"],
+                data_max=stats["max"],
+                num_candidates=1000,
+                out_dim=stats["min"].shape[0],
+            )  # (N, D)
+            candidates[action_key] = single_actions.unsqueeze(1).expand(
+                -1, self.prediction_horizon, -1
+            )
+        return candidates
+
+    def _collect_chunk_samples(
+        self,
+        normalizer: LinearNormalizer,
+        action_keys: list[str],
+    ) -> dict[str, torch.Tensor] | None:
+        """Gather aligned normalized chunk subsamples for the given keys.
+
+        Args:
+            normalizer: Normalizer possibly carrying chunk subsamples.
+            action_keys: Gaussian action keys to collect chunks for.
+
+        Returns:
+            Dict of ``(N, H, D)`` normalized chunks per key, or ``None`` when
+            any key lacks a chunk subsample.
+
+        Raises:
+            ValueError: If chunk counts differ across keys or the chunk horizon
+                does not match the decoder prediction horizon.
+        """
+        chunk_samples: dict[str, torch.Tensor] = {}
+        for action_key in action_keys:
+            chunks = normalizer[action_key].get_output_sample_chunks()
+            if chunks is None or chunks.numel() == 0:
+                return None
+            chunk_samples[action_key] = chunks
+        chunk_counts = {chunks.shape[0] for chunks in chunk_samples.values()}
+        if len(chunk_counts) != 1:
+            raise ValueError(
+                f"Chunk subsamples are not aligned across action keys: "
+                f"{ {key: chunks.shape[0] for key, chunks in chunk_samples.items()} }"
+            )
+        chunk_horizons = {chunks.shape[1] for chunks in chunk_samples.values()}
+        if chunk_horizons != {self.prediction_horizon}:
+            raise ValueError(
+                f"Chunk subsample horizon {chunk_horizons} does not match "
+                f"prediction_horizon {self.prediction_horizon}."
+            )
+        return chunk_samples
+
+    def _initialize_gaussian_mixture(
+        self,
+        normalizer: LinearNormalizer,
+        action_keys: list[str],
+        chunk_samples: dict[str, torch.Tensor],
+    ) -> None:
+        """Initialize components as trajectories selected in chunk space.
+
+        Note:
+            Chunks are clamped to the normalized data range (they are stored
+            un-winsorized). With the k-means++ strategy, flattened chunks are
+            concatenated across keys so k-means++ selects joint demonstrated
+            trajectory modes. With the uniform strategy, component ``k``
+            interpolates the per-timestep envelope of the chunk sample at
+            fraction ``k / (K - 1)``, using the same fraction for every key.
+            Each selected trajectory is written in-place into the component's
+            temporal bias, giving time-varying initial means.
+
+        Args:
+            normalizer: Normalizer with fitted statistics.
+            action_keys: Gaussian action keys, ordered as concatenated.
+            chunk_samples: Aligned ``(N, H, D)`` normalized chunks per key.
+        """
+        output_stats_by_key = {
+            action_key: normalizer.get_output_stats(key=action_key)
+            for action_key in action_keys
+        }
+        clamped_chunks: dict[str, torch.Tensor] = {}
+        for action_key in action_keys:
+            stats = output_stats_by_key[action_key]
+            chunks = chunk_samples[action_key].to(
+                dtype=stats["min"].dtype, device=stats["min"].device
+            )
+            clamped_chunks[action_key] = chunks.clamp(
+                min=stats["min"], max=stats["max"]
+            )
+        if self.gmm_init_strategy == GMMInitStrategy.KMEANS_PLUS_PLUS.value:
+            centers_by_key = self._compute_chunk_kmeans_centers(
+                clamped_chunks=clamped_chunks, action_keys=action_keys
+            )
+        else:
+            centers_by_key = self._compute_chunk_uniform_centers(
+                clamped_chunks=clamped_chunks
+            )
+        for action_key in action_keys:
+            stats = output_stats_by_key[action_key]
+            expert_logvar = self._chunk_logvar(
+                data_min=stats["min"], data_max=stats["max"]
+            )
+            for k, head in enumerate(self.mixture_heads[action_key]):
+                self._initialize_single_gaussian_head(
+                    head=head,
+                    logvar=expert_logvar,
+                    temporal_mean=centers_by_key[action_key][k],
                 )
+
+    def _compute_chunk_kmeans_centers(
+        self,
+        clamped_chunks: dict[str, torch.Tensor],
+        action_keys: list[str],
+    ) -> dict[str, torch.Tensor]:
+        """Select K demonstrated chunks via joint k-means++ across keys.
+
+        Args:
+            clamped_chunks: Aligned ``(N, H, D)`` normalized chunks per key.
+            action_keys: Gaussian action keys, ordered as concatenated.
+
+        Returns:
+            Per-key ``(K, H, D)`` trajectory centers with shared component
+            indices across keys.
+        """
+        candidate_points = torch.cat(
+            [clamped_chunks[key].flatten(start_dim=1) for key in action_keys],
+            dim=1,
+        )  # (N, H * total_dim)
+        centers = self._compute_kmeans_plus_plus_centers(
+            candidate_points=candidate_points,
+            number_of_mixture_components=self.num_mixture_components,
+        )
+        centers_by_key: dict[str, torch.Tensor] = {}
+        column_offset = 0
+        for action_key in action_keys:
+            horizon, out_dim = clamped_chunks[action_key].shape[1:]
+            width = horizon * out_dim
+            centers_by_key[action_key] = centers[
+                :, column_offset : column_offset + width
+            ].view(self.num_mixture_components, horizon, out_dim)
+            column_offset += width
+        return centers_by_key
+
+    def _compute_chunk_uniform_centers(
+        self,
+        clamped_chunks: dict[str, torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """Spread K trajectory centers across the chunk sample envelope.
+
+        Component ``k`` interpolates between the per-timestep minimum and
+        maximum of the chunk sample at fraction ``k / (K - 1)``. The fraction
+        is shared across keys, so component indices stay in correspondence.
+
+        Args:
+            clamped_chunks: Aligned ``(N, H, D)`` normalized chunks per key.
+
+        Returns:
+            Per-key ``(K, H, D)`` trajectory centers.
+        """
+        return {
+            action_key: self._compute_uniform_centers(
+                data_min=chunks.amin(dim=0),
+                data_max=chunks.amax(dim=0),
+                number_of_mixture_components=self.num_mixture_components,
+            )
+            for action_key, chunks in clamped_chunks.items()
+        }
+
+    def _chunk_logvar(
+        self,
+        data_min: torch.Tensor,
+        data_max: torch.Tensor,
+    ) -> torch.Tensor:
+        """Initial per-dimension logvar tempered by the prediction horizon.
+
+        Args:
+            data_min: Per-dimension normalized minimum.
+            data_max: Per-dimension normalized maximum.
+
+        Returns:
+            ``(D,)`` logvar tensor equal to ``2 log(range / 2) + log(horizon)``.
+        """
+        expert_sigma = ((data_max - data_min) / 2.0).clamp(min=1e-6)
+        return 2 * torch.log(expert_sigma) + math.log(self.prediction_horizon)
 
     def _initialize_gating_network(self) -> None:
         """Zero-initialize gating network for uniform initial mixture weights."""
@@ -276,61 +503,6 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
                 if isinstance(final_layer, nn.Linear):
                     nn.init.zeros_(final_layer.weight)
                     nn.init.zeros_(final_layer.bias)
-
-    def _initialize_gaussian_mixture(
-        self,
-        action_key: str,
-        output_stats: dict[str, torch.Tensor],
-        candidate_sample: torch.Tensor | None = None,
-    ) -> None:
-        """Initialize Gaussian mixture heads from output statistics.
-
-        Args:
-            action_key: Key for the action head.
-            output_stats: Dict with "min", "max", "std" tensors from normalizer.get_output_stats().
-            candidate_sample: Optional (N, out_dim) tensor of normalized action samples
-                to use as the candidate pool for k-means++. When supplied, k-means++
-                picks centers from actual action data, so centers land near true data
-                modes. When ``None``, the candidate pool is sampled uniformly from
-                ``[data_min, data_max]`` and reflects only the bounding box, not the
-                modal structure.
-        """
-        data_min = output_stats["min"]
-        data_max = output_stats["max"]
-        out_dim = data_min.shape[0]
-        if self.gmm_init_strategy == GMMInitStrategy.KMEANS_PLUS_PLUS.value:
-            if candidate_sample is not None and candidate_sample.numel() > 0:
-                candidate_points = candidate_sample.to(
-                    dtype=data_min.dtype, device=data_min.device
-                )
-            else:
-                candidate_points = self._sample_uniform_candidates(
-                    data_min=data_min,
-                    data_max=data_max,
-                    num_candidates=1000,
-                    out_dim=out_dim,
-                )
-            centers = self._compute_kmeans_plus_plus_centers(
-                candidate_points=candidate_points,
-                number_of_mixture_components=self.num_mixture_components,
-            )
-        else:
-            centers = self._compute_uniform_centers(
-                data_min=data_min,
-                data_max=data_max,
-                number_of_mixture_components=self.num_mixture_components,
-            )
-
-        data_range = data_max - data_min
-        # QFAT-style fixed variance: sigma = half-range, regardless of K.
-        # For [-1, 1] normalized data this gives sigma = 1, so every component
-        # has non-trivial responsibility for every data point at init.
-        expert_sigma = (data_range / 2.0).clamp(min=1e-6)
-        expert_logvar = 2 * torch.log(expert_sigma)
-        for k, head in enumerate(self.mixture_heads[action_key]):
-            self._initialize_single_gaussian_head(
-                head=head, mean=centers[k], logvar=expert_logvar
-            )
 
     @staticmethod
     def _compute_kmeans_plus_plus_centers(
@@ -354,6 +526,10 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
             Tensor of shape ``(K, out_dim)`` with selected centers.
         """
         num_candidates = candidate_points.shape[0]
+        if num_candidates == 0:
+            raise ValueError(
+                "Cannot initialize k-means++ centers from zero candidates."
+            )
         first_center_idx = torch.randint(0, num_candidates, (1,)).item()
         selected_centers = candidate_points[first_center_idx].unsqueeze(0)
         for _ in range(1, number_of_mixture_components):
@@ -361,10 +537,12 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
                 candidate_points, selected_centers, p=2
             ).pow(2)
             distance_to_nearest_center, _ = torch.min(squared_distances, dim=1)
-            selection_probabilities = (
-                distance_to_nearest_center / distance_to_nearest_center.sum()
-            )
-            next_center_idx = torch.multinomial(selection_probabilities, 1).item()
+            distance_sum = distance_to_nearest_center.sum()
+            if distance_sum <= 0:
+                next_center_idx = selected_centers.shape[0] % num_candidates
+            else:
+                selection_probabilities = distance_to_nearest_center / distance_sum
+                next_center_idx = torch.multinomial(selection_probabilities, 1).item()
             selected_centers = torch.cat(
                 [selected_centers, candidate_points[next_center_idx].unsqueeze(0)],
                 dim=0,
@@ -399,15 +577,17 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
         data_max: torch.Tensor,
         number_of_mixture_components: int,
     ) -> torch.Tensor:
-        """Compute K centers using uniform spread.
+        """Compute K centers interpolating uniformly between two bounds.
 
         Args:
-            data_min: Min values per dimension from output stats.
-            data_max: Max values per dimension from output stats.
+            data_min: Lower bound, ``(D,)`` per-step stats or ``(H, D)``
+                chunk envelopes.
+            data_max: Upper bound, same shape as ``data_min``.
             number_of_mixture_components: Number of mixture components.
 
         Returns:
-            Tensor of shape (K, out_dim) with uniformly spread centers.
+            Tensor of shape ``(K, *data_min.shape)`` with uniformly spread
+            centers.
         """
         centers = []
         for k in range(number_of_mixture_components):
@@ -423,20 +603,29 @@ class MixtureOfDensitiesActionTransformer(BaseParallelTransformerDecoder):
     @staticmethod
     def _initialize_single_gaussian_head(
         head: GaussianHead,
-        mean: torch.Tensor,
         logvar: torch.Tensor,
+        temporal_mean: torch.Tensor,
     ) -> None:
-        """Initialize a single Gaussian head with given mean and logvar.
+        """Bias-only initialization of a single Gaussian component head.
+
+        Projection weights and the constant bias are zeroed so the initial
+        mean equals the temporal bias trajectory. The head's ``max_logvar``
+        is raised when the requested logvar exceeds it, so horizon-tempered
+        variances are not silently clamped away.
 
         Args:
             head: GaussianHead to initialize.
-            mean: Mean tensor for output_proj bias.
-            logvar: Logvar tensor for _logvar_proj bias.
+            logvar: ``(D,)`` logvar written to the logvar projection bias.
+            temporal_mean: ``(H, D)`` trajectory written to the temporal bias.
         """
         with torch.no_grad():
             nn.init.zeros_(head.output_proj.weight)
             nn.init.zeros_(head._logvar_proj.weight)
-            head.output_proj.bias.copy_(mean)
+            head.output_proj.bias.zero_()
+            head.temporal_bias.copy_(temporal_mean)
+            max_requested_logvar = float(logvar.max().item())
+            if max_requested_logvar > head.max_logvar:
+                head.max_logvar = max_requested_logvar
             head._logvar_proj.bias.copy_(
                 logvar.clamp(min=head.min_logvar, max=head.max_logvar)
             )

--- a/src/versatil/validation.py
+++ b/src/versatil/validation.py
@@ -15,11 +15,15 @@ from versatil.data.constants import (
 from versatil.data.metadata import CameraMetadata, ObservationMetadata
 from versatil.data.task import ActionSpace, ObservationSpace
 from versatil.metrics.base import BaseLoss, _merge_weights
+from versatil.metrics.losses.mixture import GaussianMixtureNLLoss
 from versatil.models.decoding.algorithm.base import DecodingAlgorithm
 from versatil.models.decoding.algorithm.variational import VariationalAlgorithm
-from versatil.models.decoding.constants import LatentKey
+from versatil.models.decoding.constants import LatentKey, MixtureSamplingMode
 from versatil.models.decoding.decoders import MoEDecoder
 from versatil.models.decoding.decoders.base import ActionDecoder
+from versatil.models.decoding.decoders.factory.mode_act import (
+    MixtureOfDensitiesActionTransformer,
+)
 from versatil.models.decoding.decoders.vlm import VLMBackboneDecoderMixin
 from versatil.models.encoding.encoders.base import EncodingMixin
 from versatil.models.encoding.pipeline import EncodingPipeline
@@ -98,6 +102,7 @@ class ExperimentValidator:
         self.validate_encoder_observation_consistency()
         self.validate_decoder_encoder_compatibility()
         self.validate_loss_algorithm_compatibility()
+        self.validate_mixture_sampling_compatibility()
         if validate_loss_keys:
             self.validate_loss_keys()
         if self.quantization_config is not None:
@@ -467,6 +472,28 @@ class ExperimentValidator:
                     f"action space (e.g. velocity or noise). Use a regression "
                     f"loss (MSE/L1) instead."
                 )
+
+    def validate_mixture_sampling_compatibility(self) -> None:
+        """Reject Gaussian sampling when fixed-variance training leaves logvar untrained."""
+        if not isinstance(self.decoder, MixtureOfDensitiesActionTransformer):
+            return
+        if (
+            self.decoder.inference_sampling_mode
+            != MixtureSamplingMode.STOCHASTIC_SAMPLE.value
+        ):
+            return
+        has_fixed_gaussian_loss = any(
+            isinstance(loss_module, GaussianMixtureNLLoss)
+            and not loss_module.learned_variance
+            for loss_module in self.loss.modules()
+        )
+        if has_fixed_gaussian_loss:
+            self.errors.append(
+                "MixtureOfDensitiesActionTransformer cannot use "
+                "STOCHASTIC_SAMPLE with fixed-variance GaussianMixtureNLLoss "
+                "because the decoder log-variance head is not trained. Use "
+                "STOCHASTIC_MEAN or DETERMINISTIC, or enable learned_variance."
+            )
 
     def validate_loss_keys(self) -> None:
         """Validate that loss keys reference valid action heads or auxiliary keys."""

--- a/tests/configs/test_loss.py
+++ b/tests/configs/test_loss.py
@@ -278,6 +278,10 @@ class TestGaussianMixtureNLLossConfig:
             config._target_ == "versatil.metrics.losses.mixture.GaussianMixtureNLLoss"
         )
 
+    def test_defaults_to_fixed_variance(self) -> None:
+        config = GaussianMixtureNLLossConfig(action_keys=["position"])
+        assert config.learned_variance is False
+
     @pytest.mark.parametrize("learned_variance", [True, False])
     def test_stores_learned_variance(self, learned_variance):
         config = GaussianMixtureNLLossConfig(

--- a/tests/data/normalization/test_normalizer.py
+++ b/tests/data/normalization/test_normalizer.py
@@ -1,5 +1,7 @@
 """Tests for versatil.data.normalization.normalizer module."""
 
+import re
+
 import numpy as np
 import pytest
 import torch
@@ -77,64 +79,6 @@ class TestSingleFieldLinearNormalizerFit:
 
         for parameter in normalizer.parameters():
             assert not parameter.requires_grad
-
-    def test_fit_without_sample_size_stores_no_sample(self, rng: np.random.Generator):
-        data = torch.from_numpy(rng.standard_normal((100, 3)).astype(np.float32))
-        normalizer = SingleFieldLinearNormalizer()
-        normalizer.fit(data=data, mode=KinematicsNormalizationType.MIN_MAX.value)
-        assert "sample" not in normalizer.params_dict
-        assert normalizer.get_input_sample() is None
-        assert normalizer.get_output_sample() is None
-
-    def test_fit_with_sample_size_stores_subsample_of_raw_data(
-        self, rng: np.random.Generator
-    ):
-        n_rows = 100
-        feature_dim = 3
-        data = torch.from_numpy(
-            rng.standard_normal((n_rows, feature_dim)).astype(np.float32)
-        )
-        normalizer = SingleFieldLinearNormalizer()
-        normalizer.fit(
-            data=data,
-            mode=KinematicsNormalizationType.MIN_MAX.value,
-            sample_size=25,
-        )
-        sample = normalizer.get_input_sample()
-        assert sample is not None
-        assert sample.shape == (25, feature_dim)
-        # Every stored row must be byte-identical to some row of the input data.
-        match_counts = (data.unsqueeze(0) == sample.unsqueeze(1)).all(dim=-1).any(dim=1)
-        assert match_counts.all(), "stored sample contains rows not in the input data"
-
-    def test_fit_sample_capped_at_number_of_rows(self, rng: np.random.Generator):
-        data = torch.from_numpy(rng.standard_normal((10, 2)).astype(np.float32))
-        normalizer = SingleFieldLinearNormalizer()
-        normalizer.fit(
-            data=data,
-            mode=KinematicsNormalizationType.MIN_MAX.value,
-            sample_size=1000,
-        )
-        sample = normalizer.get_input_sample()
-        assert sample.shape == (10, 2)
-
-    def test_get_output_sample_applies_forward_normalization(self):
-        data = torch.tensor([[0.0, 0.0], [10.0, 20.0], [5.0, 10.0]])
-        normalizer = SingleFieldLinearNormalizer()
-        normalizer.fit(
-            data=data,
-            mode=KinematicsNormalizationType.MIN_MAX.value,
-            output_min=-1.0,
-            output_max=1.0,
-            sample_size=3,
-        )
-        raw_sample = normalizer.get_input_sample()
-        output_sample = normalizer.get_output_sample()
-        expected = normalizer.normalize(raw_sample)
-        torch.testing.assert_close(output_sample, expected, atol=1e-6, rtol=0)
-        # Output sample must lie within [-1, 1].
-        assert (output_sample >= -1.0 - 1e-6).all()
-        assert (output_sample <= 1.0 + 1e-6).all()
 
 
 class TestSingleFieldLinearNormalizerNormalize:
@@ -444,85 +388,107 @@ class TestLinearNormalizerDictFit:
 
         assert "_default" in normalizer.params_dict
 
-    def test_fit_scalar_sample_size_stores_sample_for_every_key(
+
+class TestLinearNormalizerSampleChunks:
+    def test_set_sample_chunks_on_unfitted_key_raises(
         self, rng: np.random.Generator
-    ):
-        data = {
-            "position": torch.from_numpy(
-                rng.standard_normal((80, 2)).astype(np.float32)
-            ),
-            "orientation": torch.from_numpy(
-                rng.standard_normal((80, 4)).astype(np.float32)
-            ),
-        }
+    ) -> None:
         normalizer = LinearNormalizer()
         normalizer.fit(
-            data=data,
+            data={
+                "position": torch.from_numpy(
+                    rng.standard_normal((50, 3)).astype(np.float32)
+                )
+            },
             mode=KinematicsNormalizationType.MIN_MAX.value,
-            sample_size=16,
         )
-        for key, expected_feature_dim in [("position", 2), ("orientation", 4)]:
-            sample = normalizer[key].get_input_sample()
-            assert sample is not None, f"missing sample for key '{key}'"
-            assert sample.shape == (16, expected_feature_dim)
+        chunks = torch.from_numpy(rng.standard_normal((8, 4, 3)).astype(np.float32))
+        expected_message = (
+            "Cannot attach sample chunks to unfitted key 'orientation'. "
+            "Fitted keys: ['position']."
+        )
+        with pytest.raises(KeyError, match=re.escape(expected_message)):
+            normalizer.set_sample_chunks(key="orientation", chunks=chunks)
 
-    def test_fit_dict_sample_size_limits_storage_to_selected_keys(
+    def test_get_input_sample_chunks_returns_stored_values(
         self, rng: np.random.Generator
-    ):
-        data = {
-            "position": torch.from_numpy(
-                rng.standard_normal((80, 2)).astype(np.float32)
-            ),
-            "orientation": torch.from_numpy(
-                rng.standard_normal((80, 4)).astype(np.float32)
-            ),
-        }
+    ) -> None:
+        data = torch.from_numpy(rng.standard_normal((50, 3)).astype(np.float32))
         normalizer = LinearNormalizer()
         normalizer.fit(
-            data=data,
+            data={"position": data},
             mode=KinematicsNormalizationType.MIN_MAX.value,
-            sample_size={"position": 32},
         )
-        assert normalizer["position"].get_input_sample() is not None
-        assert normalizer["position"].get_input_sample().shape == (32, 2)
-        assert normalizer["orientation"].get_input_sample() is None
+        chunks = torch.from_numpy(rng.standard_normal((8, 4, 3)).astype(np.float32))
+        normalizer.set_sample_chunks(key="position", chunks=chunks)
+        stored = normalizer["position"].get_input_sample_chunks()
+        assert stored.shape == (8, 4, 3)
+        torch.testing.assert_close(stored, chunks, atol=0, rtol=0)
 
-    def test_fit_zero_sample_size_stores_no_sample(self, rng: np.random.Generator):
-        data = {
-            "position": torch.from_numpy(
-                rng.standard_normal((80, 2)).astype(np.float32)
-            ),
-        }
+    def test_get_sample_chunks_none_when_absent(self, rng: np.random.Generator) -> None:
+        data = torch.from_numpy(rng.standard_normal((50, 3)).astype(np.float32))
         normalizer = LinearNormalizer()
         normalizer.fit(
-            data=data,
+            data={"position": data},
             mode=KinematicsNormalizationType.MIN_MAX.value,
-            sample_size=0,
         )
-        assert normalizer["position"].get_input_sample() is None
+        assert normalizer["position"].get_input_sample_chunks() is None
+        assert normalizer["position"].get_output_sample_chunks() is None
 
-    def test_state_dict_round_trip_preserves_stored_sample(
+    def test_get_output_sample_chunks_applies_forward_normalization(self) -> None:
+        data = torch.tensor([[0.0, 0.0], [10.0, 20.0], [5.0, 10.0]])
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={"position": data},
+            mode=KinematicsNormalizationType.MIN_MAX.value,
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        chunks = torch.tensor(
+            [[[0.0, 0.0], [10.0, 20.0]], [[5.0, 10.0], [0.0, 20.0]]]
+        )  # (2, 2, 2)
+        normalizer.set_sample_chunks(key="position", chunks=chunks)
+        output_chunks = normalizer["position"].get_output_sample_chunks()
+        expected = normalizer["position"].normalize(chunks)
+        torch.testing.assert_close(output_chunks, expected, atol=1e-6, rtol=0)
+        assert (output_chunks >= -1.0 - 1e-6).all()
+        assert (output_chunks <= 1.0 + 1e-6).all()
+
+    def test_set_sample_chunks_accepts_numpy_and_converts_dtype(
         self, rng: np.random.Generator
-    ):
-        data = {
-            "position": torch.from_numpy(
-                rng.standard_normal((60, 2)).astype(np.float32)
-            ),
-        }
+    ) -> None:
+        data = torch.from_numpy(rng.standard_normal((50, 3)).astype(np.float32))
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={"position": data},
+            mode=KinematicsNormalizationType.MIN_MAX.value,
+        )
+        chunks = rng.standard_normal((8, 4, 3)).astype(np.float64)
+        normalizer.set_sample_chunks(key="position", chunks=chunks)
+        stored = normalizer["position"].get_input_sample_chunks()
+        assert stored.dtype == torch.float32
+        torch.testing.assert_close(
+            stored, torch.from_numpy(chunks).to(torch.float32), atol=0, rtol=0
+        )
+
+    def test_sample_chunks_survive_state_dict_roundtrip(
+        self, rng: np.random.Generator
+    ) -> None:
+        data = torch.from_numpy(rng.standard_normal((50, 3)).astype(np.float32))
         source = LinearNormalizer()
         source.fit(
-            data=data,
+            data={"position": data},
             mode=KinematicsNormalizationType.MIN_MAX.value,
-            sample_size=16,
         )
-        source_sample = source["position"].get_input_sample()
+        chunks = torch.from_numpy(rng.standard_normal((8, 4, 3)).astype(np.float32))
+        source.set_sample_chunks(key="position", chunks=chunks)
 
         target = LinearNormalizer()
         target.load_state_dict(source.state_dict())
-        target_sample = target["position"].get_input_sample()
+        target_chunks = target["position"].get_input_sample_chunks()
 
-        assert target_sample is not None
-        torch.testing.assert_close(target_sample, source_sample, atol=0, rtol=0)
+        assert target_chunks is not None
+        torch.testing.assert_close(target_chunks, chunks, atol=0, rtol=0)
 
 
 class TestLinearNormalizerNormalize:

--- a/tests/data/processing/test_transform_builder.py
+++ b/tests/data/processing/test_transform_builder.py
@@ -801,84 +801,6 @@ class TestCreateNormalizer:
         assert "position" in fit_call_data
         assert Cameras.LEFT.value not in fit_call_data
 
-    def test_passes_action_sample_size_only_for_action_keys(
-        self,
-        transform_builder_factory: Callable[..., TransformBuilder],
-        position_observation_metadata_factory: Callable[
-            ..., PositionObservationMetadata
-        ],
-        on_the_fly_action_metadata_factory: Callable[..., OnTheFlyActionMetadata],
-        rng: np.random.Generator,
-    ):
-        position_source = position_observation_metadata_factory(dimension=3)
-        position_data = rng.standard_normal((100, 3)).astype(np.float32)
-
-        builder = transform_builder_factory(
-            observations_metadata={"position": position_source},
-            replay_buffer_data={"position": position_data},
-            action_sample_size=256,
-        )
-
-        action_meta = {
-            "position_action": on_the_fly_action_metadata_factory(
-                source_metadata=position_source,
-            )
-        }
-        action_data = {
-            "position_action": rng.standard_normal((99, 3)).astype(np.float32)
-        }
-
-        mock_normalizer = MagicMock()
-        with (
-            patch(
-                "versatil.data.processing.transform_builder.LinearNormalizer",
-                return_value=mock_normalizer,
-            ),
-            patch.object(builder, "_setup_image_normalizers"),
-            patch.object(builder, "_log_normalized_proprio_stats"),
-        ):
-            builder._create_normalizer(action_data=action_data, action_meta=action_meta)
-
-        passed_sample_size = mock_normalizer.fit.call_args[1]["sample_size"]
-        assert passed_sample_size == {"position_action": 256}
-
-    def test_action_sample_size_zero_disables_sample_storage(
-        self,
-        transform_builder_factory: Callable[..., TransformBuilder],
-        position_observation_metadata_factory: Callable[
-            ..., PositionObservationMetadata
-        ],
-        on_the_fly_action_metadata_factory: Callable[..., OnTheFlyActionMetadata],
-        rng: np.random.Generator,
-    ):
-        position_source = position_observation_metadata_factory(dimension=3)
-        builder = transform_builder_factory(
-            observations_metadata={"position": position_source},
-            replay_buffer_data={
-                "position": rng.standard_normal((100, 3)).astype(np.float32)
-            },
-            action_sample_size=0,
-        )
-        action_meta = {
-            "position_action": on_the_fly_action_metadata_factory(
-                source_metadata=position_source,
-            )
-        }
-        action_data = {
-            "position_action": rng.standard_normal((99, 3)).astype(np.float32)
-        }
-        mock_normalizer = MagicMock()
-        with (
-            patch(
-                "versatil.data.processing.transform_builder.LinearNormalizer",
-                return_value=mock_normalizer,
-            ),
-            patch.object(builder, "_setup_image_normalizers"),
-            patch.object(builder, "_log_normalized_proprio_stats"),
-        ):
-            builder._create_normalizer(action_data=action_data, action_meta=action_meta)
-        assert mock_normalizer.fit.call_args[1]["sample_size"] == 0
-
     def test_raises_for_non_numerical_observation_needing_normalization(
         self,
         transform_builder_factory: Callable[..., TransformBuilder],
@@ -1093,6 +1015,269 @@ class TestCreateNormalizerAndTokenizer:
 
         stats = normalizer["position"].get_input_stats()
         assert stats["max"].item() < 900.0
+
+
+@pytest.mark.unit
+class TestActionChunkSampling:
+    def test_sample_chunk_start_indices_stay_within_episodes(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        builder = transform_builder_factory(
+            n_steps=25,
+            episode_ends=np.array([10, 25]),
+            prediction_horizon=4,
+            action_sample_size=100,
+        )
+        start_indices = builder._sample_chunk_start_indices(row_count=24)
+        # Episode rows exclude each episode's final row: [0, 9) and [10, 24).
+        # A window of 4 fits at starts 0..5 and 10..20.
+        expected_starts = set(range(0, 6)) | set(range(10, 21))
+        assert set(start_indices.tolist()) == expected_starts
+        assert len(start_indices) == len(set(start_indices.tolist()))
+
+    def test_sample_chunk_start_indices_skip_unselected_episodes(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        builder = transform_builder_factory(
+            n_steps=25,
+            episode_ends=np.array([10, 25]),
+            prediction_horizon=4,
+            action_sample_size=100,
+            episode_selection_mask=np.array([True, False]),
+        )
+        start_indices = builder._sample_chunk_start_indices(row_count=24)
+        assert set(start_indices.tolist()) == set(range(0, 6))
+
+    def test_sample_chunk_start_indices_skip_episodes_shorter_than_window(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        builder = transform_builder_factory(
+            n_steps=20,
+            episode_ends=np.array([3, 20]),
+            prediction_horizon=4,
+            action_sample_size=100,
+        )
+        start_indices = builder._sample_chunk_start_indices(row_count=19)
+        # First episode has rows [0, 2): too short for a window of 4.
+        assert set(start_indices.tolist()) == set(range(3, 16))
+
+    def test_sample_chunk_start_indices_capped_at_sample_size(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        builder = transform_builder_factory(
+            n_steps=100,
+            episode_ends=np.array([100]),
+            prediction_horizon=4,
+            action_sample_size=5,
+        )
+        start_indices = builder._sample_chunk_start_indices(row_count=99)
+        assert start_indices.shape == (5,)
+        assert len(set(start_indices.tolist())) == 5
+
+    def test_sample_chunk_start_indices_include_final_rows_for_precomputed_actions(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        builder = transform_builder_factory(
+            n_steps=10,
+            episode_ends=np.array([10]),
+            prediction_horizon=4,
+            action_sample_size=100,
+        )
+        start_indices = builder._sample_chunk_start_indices(
+            row_count=10,
+            requires_next_observation=False,
+        )
+        assert set(start_indices.tolist()) == set(range(0, 7))
+
+    def test_stash_action_chunk_samples_stores_aligned_windows(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        horizon = 4
+        builder = transform_builder_factory(
+            n_steps=50,
+            episode_ends=np.array([50]),
+            prediction_horizon=horizon,
+            action_sample_size=16,
+        )
+        row_values = np.arange(49, dtype=np.float32)
+        action_data = {
+            "position": np.tile(row_values[:, None], (1, 3)),
+            "orientation": 1000.0 + np.tile(row_values[:, None], (1, 2)),
+        }
+        normalizer = MagicMock(spec=LinearNormalizer)
+        builder._stash_action_chunk_samples(
+            normalizer=normalizer,
+            action_data=action_data,
+            action_keys=["position", "orientation"],
+        )
+        assert normalizer.set_sample_chunks.call_count == 2
+        position_call, orientation_call = normalizer.set_sample_chunks.call_args_list
+        assert position_call.kwargs["key"] == "position"
+        assert orientation_call.kwargs["key"] == "orientation"
+        position_chunks = position_call.kwargs["chunks"]
+        orientation_chunks = orientation_call.kwargs["chunks"]
+        assert position_chunks.shape == (16, horizon, 3)
+        assert orientation_chunks.shape == (16, horizon, 2)
+        # Each window holds consecutive rows and both keys share window starts.
+        for chunk_index in range(16):
+            start_row = position_chunks[chunk_index, 0, 0]
+            expected_rows = start_row + np.arange(horizon, dtype=np.float32)
+            np.testing.assert_array_equal(
+                position_chunks[chunk_index, :, 0], expected_rows
+            )
+            np.testing.assert_array_equal(
+                orientation_chunks[chunk_index, :, 0],
+                1000.0 + expected_rows,
+            )
+
+    def test_stash_action_chunk_samples_noop_when_sample_size_zero(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        builder = transform_builder_factory(
+            n_steps=50,
+            episode_ends=np.array([50]),
+            prediction_horizon=4,
+            action_sample_size=0,
+        )
+        action_data = {"position": np.zeros((49, 3), dtype=np.float32)}
+        normalizer = MagicMock(spec=LinearNormalizer)
+        builder._stash_action_chunk_samples(
+            normalizer=normalizer,
+            action_data=action_data,
+            action_keys=["position"],
+        )
+        normalizer.set_sample_chunks.assert_not_called()
+
+    def test_stash_action_chunk_samples_can_store_length_horizon_precomputed_episode(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+    ) -> None:
+        horizon = 4
+        builder = transform_builder_factory(
+            n_steps=horizon,
+            episode_ends=np.array([horizon]),
+            prediction_horizon=horizon,
+            action_sample_size=10,
+        )
+        action_data = {
+            "position": np.arange(horizon, dtype=np.float32).reshape(horizon, 1),
+        }
+        normalizer = MagicMock(spec=LinearNormalizer)
+        builder._stash_action_chunk_samples(
+            normalizer=normalizer,
+            action_data=action_data,
+            action_keys=["position"],
+            requires_next_observation=False,
+        )
+        normalizer.set_sample_chunks.assert_called_once()
+        call = normalizer.set_sample_chunks.call_args
+        assert call.kwargs["key"] == "position"
+        chunks = call.kwargs["chunks"]
+        assert chunks.shape == (1, horizon, 1)
+        np.testing.assert_array_equal(
+            chunks,
+            action_data["position"].reshape(1, horizon, 1),
+        )
+
+
+@pytest.mark.integration
+class TestActionChunkSamplingIntegration:
+    def test_create_normalizer_and_tokenizer_stashes_chunk_samples(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+        position_observation_metadata_factory: Callable[
+            ..., PositionObservationMetadata
+        ],
+        on_the_fly_action_metadata_factory: Callable[..., OnTheFlyActionMetadata],
+        rng: np.random.Generator,
+    ) -> None:
+        horizon = 4
+        position_source = position_observation_metadata_factory(dimension=3)
+        position_data = rng.standard_normal((20, 3)).astype(np.float32)
+        builder = transform_builder_factory(
+            observations_metadata={"position": position_source},
+            actions_metadata={
+                "position": on_the_fly_action_metadata_factory(
+                    source_metadata=position_source,
+                ),
+            },
+            replay_buffer_data={"position": position_data},
+            n_steps=20,
+            episode_ends=np.array([10, 20]),
+            prediction_horizon=horizon,
+            action_sample_size=8,
+        )
+        action_rows = rng.standard_normal((19, 3)).astype(np.float32)
+        builder.action_processor.compute_sample_actions.return_value = (
+            {"position": action_rows},
+            {
+                "position": on_the_fly_action_metadata_factory(
+                    source_metadata=position_source,
+                )
+            },
+        )
+
+        normalizer, _ = builder.create_normalizer_and_tokenizer()
+
+        chunks = normalizer["position"].get_input_sample_chunks()
+        assert chunks is not None
+        assert chunks.shape == (8, horizon, 3)
+        # Every stored window must reproduce consecutive action rows from
+        # within a single episode.
+        action_rows_tensor = torch.from_numpy(action_rows)
+        valid_starts = set(range(0, 6)) | set(range(10, 16))
+        for chunk_index in range(8):
+            matched_start = None
+            for start_row in valid_starts:
+                window = action_rows_tensor[start_row : start_row + horizon]
+                if torch.equal(chunks[chunk_index], window):
+                    matched_start = start_row
+                    break
+            assert matched_start is not None, (
+                f"chunk {chunk_index} is not a within-episode window of the action rows"
+            )
+
+    def test_create_normalizer_and_tokenizer_uses_full_rows_for_precomputed_chunks(
+        self,
+        transform_builder_factory: Callable[..., TransformBuilder],
+        precomputed_action_metadata_factory: Callable[..., PrecomputedActionMetadata],
+    ) -> None:
+        horizon = 4
+        action_metadata = precomputed_action_metadata_factory(
+            storage_dimension=1,
+            prediction_dimension=1,
+        )
+        precomputed_actions = np.arange(horizon, dtype=np.float32).reshape(horizon, 1)
+        builder = transform_builder_factory(
+            actions_metadata={"action": action_metadata},
+            replay_buffer_data={"action": precomputed_actions},
+            n_steps=horizon,
+            episode_ends=np.array([horizon]),
+            prediction_horizon=horizon,
+            action_sample_size=10,
+        )
+        builder.action_processor.compute_sample_actions.return_value = (
+            {"action": precomputed_actions[:-1]},
+            {"action": action_metadata},
+        )
+
+        normalizer, _ = builder.create_normalizer_and_tokenizer()
+
+        chunks = normalizer["action"].get_input_sample_chunks()
+        assert chunks.shape == (1, horizon, 1)
+        torch.testing.assert_close(
+            chunks,
+            torch.from_numpy(precomputed_actions).view(1, horizon, 1),
+            atol=0,
+            rtol=0,
+        )
 
 
 class TestCreateTokenizer:

--- a/tests/metrics/losses/test_mixture.py
+++ b/tests/metrics/losses/test_mixture.py
@@ -22,6 +22,11 @@ class TestGaussianMixtureNLLossGetRequiredKeys:
         loss = GaussianMixtureNLLoss(action_keys=["position", "orientation"])
         assert loss.get_required_keys() == {"position", "orientation"}
 
+    def test_defaults_to_fixed_sigma_point_five(self) -> None:
+        loss = GaussianMixtureNLLoss(action_keys=["position", "orientation"])
+        assert loss.learned_variance is False
+        assert loss.sigmas == {"position": 0.5, "orientation": 0.5}
+
 
 @pytest.mark.unit
 class TestGaussianMixtureNLLossForward:

--- a/tests/models/decoding/action_heads/test_gaussian.py
+++ b/tests/models/decoding/action_heads/test_gaussian.py
@@ -2,6 +2,7 @@
 
 import re
 from collections.abc import Callable
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -148,4 +149,136 @@ class TestGaussianHeadForward:
         assert not torch.allclose(
             mutated[DecoderOutputKey.LOGVAR.value],
             head.output_proj(embedding),
+        )
+
+
+class TestGaussianHeadTemporalBias:
+    @pytest.mark.unit
+    def test_enable_before_set_output_dim_raises(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+    ) -> None:
+        head = gaussian_head_factory(input_dimension=64)
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape("output_dim not set. Call set_output_dim() first."),
+        ):
+            head.enable_temporal_bias(horizon=8)
+
+    @pytest.mark.parametrize("horizon", [1, 8])
+    @pytest.mark.parametrize("output_dim", [3, 7])
+    @pytest.mark.unit
+    def test_creates_zero_bias_with_horizon_shape(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+        horizon: int,
+        output_dim: int,
+    ) -> None:
+        head = gaussian_head_factory(input_dimension=64, output_dim=output_dim)
+        head.enable_temporal_bias(horizon=horizon)
+        assert head.temporal_bias.shape == (horizon, output_dim)
+        torch.testing.assert_close(
+            head.temporal_bias,
+            torch.zeros(horizon, output_dim),
+            atol=0,
+            rtol=0,
+        )
+        assert head.temporal_bias.requires_grad is True
+
+    @pytest.mark.unit
+    def test_forward_adds_temporal_bias_after_mean_projection(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+        embedding_tensor_factory: Callable[..., torch.Tensor],
+    ) -> None:
+        horizon = 8
+        output_dimension = 3
+        head = gaussian_head_factory(input_dimension=64, output_dim=output_dimension)
+        head.enable_temporal_bias(horizon=horizon)
+        embedding = embedding_tensor_factory(
+            embedding_dimension=64,
+            prediction_horizon=horizon,
+        )
+        projected_mean = torch.zeros(2, horizon, output_dimension)
+        projected_logvar = torch.zeros_like(projected_mean)
+        temporal_bias = torch.arange(
+            horizon * output_dimension,
+            dtype=torch.float32,
+        ).view(horizon, output_dimension)
+        with (
+            torch.no_grad(),
+            patch.object(head, "_apply_blocks", return_value=embedding) as apply_blocks,
+            patch.object(
+                head.output_proj,
+                "forward",
+                return_value=projected_mean,
+            ) as mean_projection,
+            patch.object(
+                head._logvar_proj,
+                "forward",
+                return_value=projected_logvar,
+            ) as logvar_projection,
+        ):
+            head.temporal_bias.copy_(temporal_bias)
+            result = head(embedding)
+
+        apply_blocks.assert_called_once_with(embedding)
+        mean_projection.assert_called_once_with(embedding)
+        logvar_projection.assert_called_once_with(embedding)
+        torch.testing.assert_close(
+            result[DecoderOutputKey.MEAN.value],
+            projected_mean + temporal_bias,
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            result[DecoderOutputKey.LOGVAR.value],
+            projected_logvar,
+            atol=0,
+            rtol=0,
+        )
+
+    @pytest.mark.integration
+    def test_zero_bias_keeps_mean_unchanged(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+        embedding_tensor_factory: Callable[..., torch.Tensor],
+    ) -> None:
+        head = gaussian_head_factory(input_dimension=64, output_dim=3)
+        head.eval()
+        embedding = embedding_tensor_factory(
+            embedding_dimension=64, prediction_horizon=8
+        )
+        baseline = head(embedding)[DecoderOutputKey.MEAN.value].clone()
+        head.enable_temporal_bias(horizon=8)
+        result = head(embedding)
+        torch.testing.assert_close(result[DecoderOutputKey.MEAN.value], baseline)
+
+    @pytest.mark.integration
+    def test_bias_shifts_mean_per_timestep(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+        embedding_tensor_factory: Callable[..., torch.Tensor],
+    ) -> None:
+        horizon = 8
+        output_dim = 3
+        head = gaussian_head_factory(input_dimension=64, output_dim=output_dim)
+        head.eval()
+        embedding = embedding_tensor_factory(
+            embedding_dimension=64, prediction_horizon=horizon
+        )
+        baseline = head(embedding)[DecoderOutputKey.MEAN.value].clone()
+        baseline_logvar = head(embedding)[DecoderOutputKey.LOGVAR.value].clone()
+        head.enable_temporal_bias(horizon=horizon)
+        trajectory = torch.arange(horizon * output_dim, dtype=torch.float32).view(
+            horizon, output_dim
+        )
+        with torch.no_grad():
+            head.temporal_bias.copy_(trajectory)
+        result = head(embedding)
+        torch.testing.assert_close(
+            result[DecoderOutputKey.MEAN.value], baseline + trajectory
+        )
+        torch.testing.assert_close(
+            result[DecoderOutputKey.LOGVAR.value], baseline_logvar
         )

--- a/tests/models/decoding/decoders/factory/test_mode_act.py
+++ b/tests/models/decoding/decoders/factory/test_mode_act.py
@@ -1,5 +1,6 @@
 """Tests for versatil.models.decoding.decoders.factory.mode_act module."""
 
+import math
 import re
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
@@ -199,6 +200,36 @@ def gaussian_mode_act_factory(
             gmm_init_strategy=gmm_init_strategy,
             inference_sampling_mode=inference_sampling_mode,
         )
+
+    return factory
+
+
+@pytest.fixture
+def trajectory_chunk_factory(
+    rng: np.random.Generator,
+) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
+    """Factory for clustered trajectory chunks with time-varying modes."""
+
+    def factory(
+        cluster_endpoints: torch.Tensor,
+        chunks_per_cluster: int = 32,
+        horizon: int = PREDICTION_HORIZON,
+        noise_scale: float = 0.005,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        number_of_clusters, action_dim = cluster_endpoints.shape
+        ramp = torch.linspace(1.0 / horizon, 1.0, horizon)  # (H,)
+        cluster_trajectories = (
+            cluster_endpoints[:, None, :] * ramp[None, :, None]
+        )  # (C, H, D)
+        noise = torch.from_numpy(
+            rng.standard_normal(
+                (number_of_clusters, chunks_per_cluster, horizon, action_dim)
+            ).astype(np.float32)
+        )
+        chunks = (cluster_trajectories[:, None, :, :] + noise_scale * noise).reshape(
+            number_of_clusters * chunks_per_cluster, horizon, action_dim
+        )
+        return chunks, cluster_trajectories
 
     return factory
 
@@ -845,6 +876,37 @@ class TestModeACTGMMInitialization:
             f"centers collapsed to fewer clusters: {nearest_cluster.tolist()}"
         )
 
+    def test_compute_kmeans_plus_plus_centers_duplicates_when_pool_is_smaller_than_k(
+        self,
+    ) -> None:
+        candidate_points = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
+        centers = MixtureOfDensitiesActionTransformer._compute_kmeans_plus_plus_centers(
+            candidate_points=candidate_points,
+            number_of_mixture_components=5,
+        )
+        assert centers.shape == (5, 2)
+        for component_index in range(5):
+            matches = (candidate_points == centers[component_index]).all(dim=1)
+            assert matches.any(), (
+                f"center {component_index} is not present in the candidate pool"
+            )
+
+    def test_compute_kmeans_plus_plus_centers_handles_identical_candidates(
+        self,
+    ) -> None:
+        candidate_points = torch.ones(3, 2)
+        centers = MixtureOfDensitiesActionTransformer._compute_kmeans_plus_plus_centers(
+            candidate_points=candidate_points,
+            number_of_mixture_components=5,
+        )
+        assert centers.shape == (5, 2)
+        torch.testing.assert_close(
+            centers,
+            torch.ones(5, 2),
+            atol=0,
+            rtol=0,
+        )
+
     def test_sample_uniform_candidates_shape_and_range(
         self,
         rng: np.random.Generator,
@@ -947,31 +1009,38 @@ class TestModeACTGMMInitialization:
 
     @pytest.mark.parametrize(
         "num_mixture_components",
-        [2, 4, 8, 16],
+        [2, 8],
     )
-    def test_initialize_gaussian_mixture_uses_qfat_style_fixed_variance(
+    def test_set_normalizer_without_chunks_uses_horizon_tempered_variance(
         self,
         gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        rng: np.random.Generator,
         num_mixture_components: int,
-    ):
+    ) -> None:
         decoder = gaussian_mode_act_factory(
             input_keys=["rgb_features"],
             num_mixture_components=num_mixture_components,
         )
         action_key = next(iter(decoder.action_heads.keys()))
         action_dim = decoder.action_heads[action_key].output_proj.bias.shape[0]
-        data_min = -torch.ones(action_dim)
-        data_max = torch.ones(action_dim)
-        decoder._initialize_gaussian_mixture(
-            action_key=action_key,
-            output_stats={"min": data_min, "max": data_max},
+        raw_data = torch.from_numpy(
+            rng.standard_normal((200, action_dim)).astype(np.float32)
         )
-        expected_logvar = 2 * torch.log(torch.ones(action_dim))
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={action_key: raw_data},
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        decoder.set_normalizer(normalizer)
+        # Normalized range is [-1, 1], so sigma = 1 and only the horizon
+        # tempering remains.
+        expected_logvar = torch.full((action_dim,), math.log(PREDICTION_HORIZON))
         for head in decoder.mixture_heads[action_key]:
             torch.testing.assert_close(
                 head._logvar_proj.bias,
                 expected_logvar.clamp(min=head.min_logvar, max=head.max_logvar),
-                atol=1e-6,
+                atol=1e-5,
                 rtol=0,
             )
             torch.testing.assert_close(
@@ -987,170 +1056,76 @@ class TestModeACTGMMInitialization:
                 rtol=0,
             )
 
-    def test_initialize_gaussian_mixture_scales_with_data_range(
+    def test_chunk_logvar_scales_with_data_range(
         self,
         gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
-    ):
+    ) -> None:
         decoder = gaussian_mode_act_factory(input_keys=["rgb_features"])
-        action_key = next(iter(decoder.action_heads.keys()))
-        action_dim = decoder.action_heads[action_key].output_proj.bias.shape[0]
-        data_min = -2.0 * torch.ones(action_dim)
-        data_max = 2.0 * torch.ones(action_dim)
-        decoder._initialize_gaussian_mixture(
-            action_key=action_key,
-            output_stats={"min": data_min, "max": data_max},
+        action_dim = 3
+        logvar = decoder._chunk_logvar(
+            data_min=-2.0 * torch.ones(action_dim),
+            data_max=2.0 * torch.ones(action_dim),
         )
-        expected_logvar = 2 * torch.log(2.0 * torch.ones(action_dim))
-        for head in decoder.mixture_heads[action_key]:
-            torch.testing.assert_close(
-                head._logvar_proj.bias,
-                expected_logvar.clamp(min=head.min_logvar, max=head.max_logvar),
-                atol=1e-6,
-                rtol=0,
-            )
+        expected_logvar = 2 * torch.log(2.0 * torch.ones(action_dim)) + math.log(
+            PREDICTION_HORIZON
+        )
+        torch.testing.assert_close(logvar, expected_logvar, atol=1e-6, rtol=0)
 
-    def test_initialize_gaussian_mixture_uses_candidate_sample_when_provided(
+    def test_raised_logvar_cap_survives_state_dict_reload(
         self,
         gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
         rng: np.random.Generator,
     ) -> None:
-        decoder = gaussian_mode_act_factory(
-            input_keys=["rgb_features"],
-            num_mixture_components=4,
-            gmm_init_strategy=GMMInitStrategy.KMEANS_PLUS_PLUS.value,
-        )
-        action_key = next(iter(decoder.action_heads.keys()))
-        action_dim = decoder.action_heads[action_key].output_proj.bias.shape[0]
-        cluster_means = torch.stack(
-            [torch.full((action_dim,), value) for value in [0.7, -0.7, 0.35, -0.35]]
-        )  # (4, action_dim) — four well-separated points on the main diagonal.
-        points_per_cluster = 64
-        candidate_sample = torch.cat(
-            [
-                cluster_means[i].unsqueeze(0)
-                + 0.005
-                * torch.from_numpy(
-                    rng.standard_normal((points_per_cluster, action_dim)).astype(
-                        np.float32
-                    )
-                )
-                for i in range(4)
-            ],
-            dim=0,
-        )
-        decoder._initialize_gaussian_mixture(
-            action_key=action_key,
-            output_stats={
-                "min": -torch.ones(action_dim),
-                "max": torch.ones(action_dim),
-            },
-            candidate_sample=candidate_sample,
-        )
-        component_biases = torch.stack(
-            [
-                decoder.mixture_heads[action_key][k].output_proj.bias.detach()
-                for k in range(4)
-            ]
-        )
-        # Each selected center must be close to one of the four cluster means;
-        # collectively the four biases must cover every cluster.
-        nearest_cluster = torch.cdist(component_biases, cluster_means).argmin(dim=1)
-        nearest_distance = (
-            torch.cdist(component_biases, cluster_means).min(dim=1).values
-        )
-        assert (nearest_distance < 0.05).all(), (
-            f"component biases drifted from candidate pool: {nearest_distance.tolist()}"
-        )
-        assert torch.unique(nearest_cluster).shape == (4,), (
-            f"components collapsed to fewer clusters: {nearest_cluster.tolist()}"
-        )
-
-    def test_initialize_gaussian_mixture_falls_back_to_uniform_without_sample(
-        self,
-        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
-    ):
-        decoder = gaussian_mode_act_factory(
-            input_keys=["rgb_features"],
-            num_mixture_components=4,
-            gmm_init_strategy=GMMInitStrategy.KMEANS_PLUS_PLUS.value,
-        )
-        action_key = next(iter(decoder.action_heads.keys()))
-        action_dim = decoder.action_heads[action_key].output_proj.bias.shape[0]
-        data_min = -torch.ones(action_dim)
-        data_max = torch.ones(action_dim)
-        decoder._initialize_gaussian_mixture(
-            action_key=action_key,
-            output_stats={"min": data_min, "max": data_max},
-            candidate_sample=None,
-        )
-        for k in range(4):
-            bias = decoder.mixture_heads[action_key][k].output_proj.bias.detach()
-            assert (bias >= data_min - 1e-5).all(), (
-                f"component {k} bias {bias.tolist()} below data_min"
-            )
-            assert (bias <= data_max + 1e-5).all(), (
-                f"component {k} bias {bias.tolist()} above data_max"
-            )
-
-    def test_set_normalizer_forwards_data_sample_to_gaussian_init(
-        self,
-        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
-        rng: np.random.Generator,
-    ) -> None:
+        prediction_horizon = 60
         action_dim = 2
         decoder = gaussian_mode_act_factory(
             input_keys=["rgb_features"],
-            num_mixture_components=4,
             position_dim=action_dim,
-            gmm_init_strategy=GMMInitStrategy.KMEANS_PLUS_PLUS.value,
+            prediction_horizon=prediction_horizon,
+            num_mixture_components=2,
         )
         action_key = next(iter(decoder.action_heads.keys()))
-        cluster_centers_raw = torch.tensor(
-            [[0.0, 0.0], [2.0, 0.0], [0.0, 2.0], [2.0, 2.0]]
-        )
-        rows_per_cluster = 100
-        raw_data = torch.cat(
-            [
-                cluster_centers_raw[i].unsqueeze(0)
-                + 0.01
-                * torch.from_numpy(
-                    rng.standard_normal((rows_per_cluster, action_dim)).astype(
-                        np.float32
-                    )
-                )
-                for i in range(4)
-            ],
-            dim=0,
+        raw_data = torch.from_numpy(
+            rng.standard_normal((200, action_dim)).astype(np.float32)
         )
         normalizer = LinearNormalizer()
         normalizer.fit(
             data={action_key: raw_data},
             output_min=-1.0,
             output_max=1.0,
-            sample_size=256,
         )
-        decoder.set_normalizer(normalizer)
-        component_biases = torch.stack(
-            [
-                decoder.mixture_heads[action_key][k].output_proj.bias.detach()
-                for k in range(4)
-            ]
+        decoder.set_normalizer(normalizer=normalizer)
+        expected_logvar = torch.full((action_dim,), math.log(prediction_horizon))
+        state_dict = decoder.state_dict()
+
+        reloaded = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=action_dim,
+            prediction_horizon=prediction_horizon,
+            num_mixture_components=2,
         )
-        expected_normalized_centers = normalizer[action_key].normalize(
-            cluster_centers_raw
+        reloaded.load_state_dict(state_dict)
+
+        head = reloaded.mixture_heads[action_key][0]
+        assert head.max_logvar == pytest.approx(math.log(prediction_horizon))
+        torch.testing.assert_close(
+            head._logvar_proj.bias,
+            expected_logvar,
+            atol=1e-6,
+            rtol=0,
         )
-        distances = torch.cdist(component_biases, expected_normalized_centers)
-        nearest_distance = distances.min(dim=1).values
-        assert (nearest_distance < 0.1).all(), (
-            f"component biases not matched to normalized cluster centers: "
-            f"{nearest_distance.tolist()}"
-        )
-        nearest_cluster = distances.argmin(dim=1)
-        assert torch.unique(nearest_cluster).shape == (4,), (
-            f"components collapsed to fewer clusters: {nearest_cluster.tolist()}"
+        action_embedding = torch.zeros(1, prediction_horizon, EMBEDDING_DIMENSION)
+        output = head(action_embedding)
+        torch.testing.assert_close(
+            output[DecoderOutputKey.LOGVAR.value],
+            expected_logvar.view(1, 1, action_dim).expand(
+                1, prediction_horizon, action_dim
+            ),
+            atol=1e-6,
+            rtol=0,
         )
 
-    def test_set_normalizer_falls_back_when_normalizer_has_no_sample(
+    def test_set_normalizer_without_chunks_uses_constant_trajectories(
         self,
         gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
         rng: np.random.Generator,
@@ -1170,15 +1145,390 @@ class TestModeACTGMMInitialization:
             data={action_key: raw_data},
             output_min=-1.0,
             output_max=1.0,
-            sample_size=0,
         )
-        assert normalizer[action_key].get_input_sample() is None
+        assert normalizer[action_key].get_input_sample_chunks() is None
         decoder.set_normalizer(normalizer)
         output_stats = normalizer[action_key].get_output_stats()
         for k in range(4):
-            bias = decoder.mixture_heads[action_key][k].output_proj.bias.detach()
-            assert (bias >= output_stats["min"] - 1e-4).all()
-            assert (bias <= output_stats["max"] + 1e-4).all()
+            head = decoder.mixture_heads[action_key][k]
+            trajectory = head.temporal_bias.detach()
+            # Candidates are single actions broadcast over the horizon, so
+            # every selected trajectory is constant in time.
+            torch.testing.assert_close(
+                trajectory,
+                trajectory[0].expand_as(trajectory),
+                atol=0,
+                rtol=0,
+            )
+            assert (trajectory >= output_stats["min"] - 1e-4).all()
+            assert (trajectory <= output_stats["max"] + 1e-4).all()
+            torch.testing.assert_close(
+                head.output_proj.bias,
+                torch.zeros(action_dim),
+                atol=0,
+                rtol=0,
+            )
+
+
+@pytest.mark.integration
+class TestInitializeSingleGaussianHead:
+    def test_raises_max_logvar_when_requested_logvar_exceeds_it(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+    ) -> None:
+        head = gaussian_head_factory(output_dim=3, max_logvar=4.0)
+        head.enable_temporal_bias(horizon=PREDICTION_HORIZON)
+        requested_logvar = torch.full((3,), 6.0)
+        MixtureOfDensitiesActionTransformer._initialize_single_gaussian_head(
+            head=head,
+            logvar=requested_logvar,
+            temporal_mean=torch.zeros(PREDICTION_HORIZON, 3),
+        )
+        assert head.max_logvar == pytest.approx(6.0)
+        torch.testing.assert_close(
+            head._logvar_proj.bias, requested_logvar, atol=1e-6, rtol=0
+        )
+
+    def test_temporal_mean_written_and_constant_bias_zeroed(
+        self,
+        gaussian_head_factory: Callable[..., GaussianHead],
+    ) -> None:
+        head = gaussian_head_factory(output_dim=3)
+        head.enable_temporal_bias(horizon=PREDICTION_HORIZON)
+        with torch.no_grad():
+            head.output_proj.bias.fill_(0.5)
+        trajectory = torch.arange(PREDICTION_HORIZON * 3, dtype=torch.float32).view(
+            PREDICTION_HORIZON, 3
+        )
+        MixtureOfDensitiesActionTransformer._initialize_single_gaussian_head(
+            head=head,
+            logvar=torch.zeros(3),
+            temporal_mean=trajectory,
+        )
+        torch.testing.assert_close(
+            head.temporal_bias.detach(), trajectory, atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            head.output_proj.bias,
+            torch.zeros(3),
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            head.output_proj.weight,
+            torch.zeros_like(head.output_proj.weight),
+            atol=0,
+            rtol=0,
+        )
+
+
+@pytest.mark.integration
+def test_gaussian_clones_created_with_zero_temporal_bias(
+    gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+) -> None:
+    decoder = gaussian_mode_act_factory()
+    for action_key, heads in decoder.mixture_heads.items():
+        action_dim = decoder.action_heads[action_key].output_proj.bias.shape[0]
+        for head in heads:
+            assert head.temporal_bias.shape == (PREDICTION_HORIZON, action_dim)
+            torch.testing.assert_close(
+                head.temporal_bias.detach(),
+                torch.zeros(PREDICTION_HORIZON, action_dim),
+                atol=0,
+                rtol=0,
+            )
+
+
+@pytest.mark.integration
+class TestModeACTChunkInitialization:
+    def test_chunk_init_writes_demonstrated_chunks_into_temporal_bias(
+        self,
+        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        trajectory_chunk_factory: Callable[..., tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        action_dim = 2
+        num_components = 3
+        decoder = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=action_dim,
+            num_mixture_components=num_components,
+            gmm_init_strategy=GMMInitStrategy.KMEANS_PLUS_PLUS.value,
+        )
+        action_key = next(iter(decoder.action_heads.keys()))
+        cluster_endpoints = torch.tensor([[2.0, 2.0], [-2.0, 2.0], [0.0, -2.0]])
+        chunks, cluster_trajectories = trajectory_chunk_factory(
+            cluster_endpoints=cluster_endpoints
+        )
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={action_key: chunks.reshape(-1, action_dim)},
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        normalizer.set_sample_chunks(key=action_key, chunks=chunks)
+        decoder.set_normalizer(normalizer)
+        normalized_candidates = normalizer[action_key].normalize(chunks)
+        normalized_cluster_trajectories = normalizer[action_key].normalize(
+            cluster_trajectories
+        )
+        component_biases = torch.stack(
+            [
+                decoder.mixture_heads[action_key][k].temporal_bias.detach()
+                for k in range(num_components)
+            ]
+        )  # (K, H, D)
+        for k in range(num_components):
+            candidate_distances = (
+                (normalized_candidates - component_biases[k]).flatten(1).norm(dim=1)
+            )
+            assert candidate_distances.min() < 1e-4, (
+                f"component {k} temporal bias is not a demonstrated chunk "
+                f"(nearest candidate distance {candidate_distances.min()})"
+            )
+            torch.testing.assert_close(
+                decoder.mixture_heads[action_key][k].output_proj.bias,
+                torch.zeros(action_dim),
+                atol=0,
+                rtol=0,
+            )
+        cluster_distances = (
+            (component_biases[:, None] - normalized_cluster_trajectories[None])
+            .flatten(2)
+            .norm(dim=2)
+        )  # (K, C)
+        nearest_cluster = cluster_distances.argmin(dim=1)
+        assert torch.unique(nearest_cluster).shape == (num_components,), (
+            f"components collapsed to fewer trajectory modes: "
+            f"{nearest_cluster.tolist()}"
+        )
+
+    def test_chunk_init_tempers_logvar_by_horizon(
+        self,
+        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        trajectory_chunk_factory: Callable[..., tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        action_dim = 2
+        decoder = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=action_dim,
+            num_mixture_components=3,
+        )
+        action_key = next(iter(decoder.action_heads.keys()))
+        cluster_endpoints = torch.tensor([[2.0, 2.0], [-2.0, 2.0], [0.0, -2.0]])
+        chunks, _ = trajectory_chunk_factory(cluster_endpoints=cluster_endpoints)
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={action_key: chunks.reshape(-1, action_dim)},
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        normalizer.set_sample_chunks(key=action_key, chunks=chunks)
+        decoder.set_normalizer(normalizer)
+        stats = normalizer[action_key].get_output_stats()
+        expected_logvar = 2 * torch.log((stats["max"] - stats["min"]) / 2.0) + math.log(
+            PREDICTION_HORIZON
+        )
+        for head in decoder.mixture_heads[action_key]:
+            torch.testing.assert_close(
+                head._logvar_proj.bias,
+                expected_logvar.clamp(min=head.min_logvar, max=head.max_logvar),
+                atol=1e-5,
+                rtol=0,
+            )
+            torch.testing.assert_close(
+                head._logvar_proj.weight,
+                torch.zeros_like(head._logvar_proj.weight),
+                atol=0,
+                rtol=0,
+            )
+            torch.testing.assert_close(
+                head.output_proj.weight,
+                torch.zeros_like(head.output_proj.weight),
+                atol=0,
+                rtol=0,
+            )
+
+    def test_chunk_init_keeps_cross_key_mode_correspondence(
+        self,
+        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        trajectory_chunk_factory: Callable[..., tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        num_components = 3
+        decoder = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=2,
+            has_orientation=True,
+            orientation_dim=2,
+            num_mixture_components=num_components,
+        )
+        position_endpoints = torch.tensor([[2.0, 2.0], [-2.0, 2.0], [0.0, -2.0]])
+        orientation_endpoints = torch.tensor([[-3.0, 0.0], [3.0, 3.0], [0.0, 3.0]])
+        position_chunks, position_trajectories = trajectory_chunk_factory(
+            cluster_endpoints=position_endpoints
+        )
+        orientation_chunks, orientation_trajectories = trajectory_chunk_factory(
+            cluster_endpoints=orientation_endpoints
+        )
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={
+                "position_action": position_chunks.reshape(-1, 2),
+                "orientation_action": orientation_chunks.reshape(-1, 2),
+            },
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        normalizer.set_sample_chunks(key="position_action", chunks=position_chunks)
+        normalizer.set_sample_chunks(
+            key="orientation_action", chunks=orientation_chunks
+        )
+        decoder.set_normalizer(normalizer)
+        normalized_position_modes = normalizer["position_action"].normalize(
+            position_trajectories
+        )
+        normalized_orientation_modes = normalizer["orientation_action"].normalize(
+            orientation_trajectories
+        )
+        for k in range(num_components):
+            position_bias = decoder.mixture_heads["position_action"][
+                k
+            ].temporal_bias.detach()
+            orientation_bias = decoder.mixture_heads["orientation_action"][
+                k
+            ].temporal_bias.detach()
+            position_cluster = (
+                (normalized_position_modes - position_bias)
+                .flatten(1)
+                .norm(dim=1)
+                .argmin()
+            )
+            orientation_cluster = (
+                (normalized_orientation_modes - orientation_bias)
+                .flatten(1)
+                .norm(dim=1)
+                .argmin()
+            )
+            assert position_cluster == orientation_cluster, (
+                f"component {k} pairs position mode {position_cluster} with "
+                f"orientation mode {orientation_cluster}"
+            )
+
+    def test_chunk_horizon_mismatch_raises(
+        self,
+        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        trajectory_chunk_factory: Callable[..., tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        action_dim = 2
+        wrong_horizon = PREDICTION_HORIZON + 1
+        decoder = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=action_dim,
+        )
+        action_key = next(iter(decoder.action_heads.keys()))
+        chunks, _ = trajectory_chunk_factory(
+            cluster_endpoints=torch.tensor([[2.0, 2.0], [-2.0, 2.0]]),
+            horizon=wrong_horizon,
+        )
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={action_key: chunks.reshape(-1, action_dim)},
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        normalizer.set_sample_chunks(key=action_key, chunks=chunks)
+        expected_message = (
+            f"Chunk subsample horizon {{{wrong_horizon}}} does not match "
+            f"prediction_horizon {PREDICTION_HORIZON}."
+        )
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            decoder.set_normalizer(normalizer)
+
+    def test_misaligned_chunk_counts_raise(
+        self,
+        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        trajectory_chunk_factory: Callable[..., tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        decoder = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=2,
+            has_orientation=True,
+            orientation_dim=2,
+        )
+        position_chunks, _ = trajectory_chunk_factory(
+            cluster_endpoints=torch.tensor([[2.0, 2.0], [-2.0, 2.0]]),
+            chunks_per_cluster=8,
+        )
+        orientation_chunks, _ = trajectory_chunk_factory(
+            cluster_endpoints=torch.tensor([[1.0, 1.0], [-1.0, 1.0]]),
+            chunks_per_cluster=4,
+        )
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={
+                "position_action": position_chunks.reshape(-1, 2),
+                "orientation_action": orientation_chunks.reshape(-1, 2),
+            },
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        normalizer.set_sample_chunks(key="position_action", chunks=position_chunks)
+        normalizer.set_sample_chunks(
+            key="orientation_action", chunks=orientation_chunks
+        )
+        chunk_counts = {
+            "position_action": position_chunks.shape[0],
+            "orientation_action": orientation_chunks.shape[0],
+        }
+        expected_message = (
+            f"Chunk subsamples are not aligned across action keys: {chunk_counts}"
+        )
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            decoder.set_normalizer(normalizer)
+
+    def test_uniform_strategy_interpolates_chunk_envelope(
+        self,
+        gaussian_mode_act_factory: Callable[..., MixtureOfDensitiesActionTransformer],
+        trajectory_chunk_factory: Callable[..., tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        action_dim = 2
+        num_components = 4
+        decoder = gaussian_mode_act_factory(
+            input_keys=["rgb_features"],
+            position_dim=action_dim,
+            num_mixture_components=num_components,
+            gmm_init_strategy=GMMInitStrategy.UNIFORM.value,
+        )
+        action_key = next(iter(decoder.action_heads.keys()))
+        chunks, _ = trajectory_chunk_factory(
+            cluster_endpoints=torch.tensor([[2.0, 2.0], [-2.0, 2.0]])
+        )
+        normalizer = LinearNormalizer()
+        normalizer.fit(
+            data={action_key: chunks.reshape(-1, action_dim)},
+            output_min=-1.0,
+            output_max=1.0,
+        )
+        normalizer.set_sample_chunks(key=action_key, chunks=chunks)
+        decoder.set_normalizer(normalizer)
+        normalized_chunks = normalizer[action_key].normalize(chunks)
+        envelope_min = normalized_chunks.amin(dim=0)  # (H, D)
+        envelope_max = normalized_chunks.amax(dim=0)  # (H, D)
+        for k in range(num_components):
+            head = decoder.mixture_heads[action_key][k]
+            alpha = k / (num_components - 1)
+            expected_trajectory = envelope_min + alpha * (envelope_max - envelope_min)
+            torch.testing.assert_close(
+                head.temporal_bias.detach(),
+                expected_trajectory,
+                atol=1e-5,
+                rtol=0,
+            )
+            torch.testing.assert_close(
+                head.output_proj.bias,
+                torch.zeros(action_dim),
+                atol=0,
+                rtol=0,
+            )
 
 
 @pytest.mark.integration

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,11 +21,19 @@ from versatil.data.constants import (
 )
 from versatil.data.metadata import DepthCameraMetadata, RGBCameraMetadata
 from versatil.metrics.base import BaseLoss
+from versatil.metrics.losses.mixture import GaussianMixtureNLLoss
 from versatil.models.decoding.algorithm.base import DecodingAlgorithm
 from versatil.models.decoding.algorithm.variational import VariationalAlgorithm
-from versatil.models.decoding.constants import DecoderOutputKey, LatentKey
+from versatil.models.decoding.constants import (
+    DecoderOutputKey,
+    LatentKey,
+    MixtureSamplingMode,
+)
 from versatil.models.decoding.decoders import MoEDecoder
 from versatil.models.decoding.decoders.base import ActionDecoder, DecoderInput
+from versatil.models.decoding.decoders.factory.mode_act import (
+    MixtureOfDensitiesActionTransformer,
+)
 from versatil.models.decoding.decoders.interleaved_vlm import (
     BaseInterleavedVLMDecoder,
 )
@@ -1826,6 +1834,58 @@ class TestValidateLossAlgorithmCompatibility:
         validator = validator_factory(algorithm=algorithm, loss=loss)
         validator.validate_loss_algorithm_compatibility()
         assert len(validator.errors) == 2
+
+
+@pytest.mark.unit
+class TestValidateMixtureSamplingCompatibility:
+    def test_rejects_fixed_variance_with_stochastic_gaussian_sampling(
+        self,
+        validator_factory: Callable[..., ExperimentValidator],
+        mock_loss_factory: Callable[..., MagicMock],
+    ) -> None:
+        decoder = MagicMock(spec=MixtureOfDensitiesActionTransformer)
+        decoder.inference_sampling_mode = MixtureSamplingMode.STOCHASTIC_SAMPLE.value
+        gaussian_loss = MagicMock(spec=GaussianMixtureNLLoss)
+        gaussian_loss.learned_variance = False
+        loss = mock_loss_factory()
+        loss.modules.return_value = [gaussian_loss]
+        validator = validator_factory(decoder=decoder, loss=loss)
+
+        validator.validate_mixture_sampling_compatibility()
+
+        assert validator.errors == [
+            "MixtureOfDensitiesActionTransformer cannot use STOCHASTIC_SAMPLE "
+            "with fixed-variance GaussianMixtureNLLoss because the decoder "
+            "log-variance head is not trained. Use STOCHASTIC_MEAN or "
+            "DETERMINISTIC, or enable learned_variance."
+        ]
+
+    @pytest.mark.parametrize(
+        ("sampling_mode", "learned_variance"),
+        [
+            (MixtureSamplingMode.STOCHASTIC_SAMPLE.value, True),
+            (MixtureSamplingMode.STOCHASTIC_MEAN.value, False),
+            (MixtureSamplingMode.DETERMINISTIC.value, False),
+        ],
+    )
+    def test_accepts_compatible_sampling_and_variance_combinations(
+        self,
+        validator_factory: Callable[..., ExperimentValidator],
+        mock_loss_factory: Callable[..., MagicMock],
+        sampling_mode: str,
+        learned_variance: bool,
+    ) -> None:
+        decoder = MagicMock(spec=MixtureOfDensitiesActionTransformer)
+        decoder.inference_sampling_mode = sampling_mode
+        gaussian_loss = MagicMock(spec=GaussianMixtureNLLoss)
+        gaussian_loss.learned_variance = learned_variance
+        loss = mock_loss_factory()
+        loss.modules.return_value = [gaussian_loss]
+        validator = validator_factory(decoder=decoder, loss=loss)
+
+        validator.validate_mixture_sampling_compatibility()
+
+        assert validator.errors == []
 
 
 class TestValidateExperiment:


### PR DESCRIPTION
Several changes related to the "Mixture-of-Density Action Transformer" policy:

- Dataloader optionally stores "example action chunks" that are used for downstream sampling of chunk-related statistics, such as the ones used for initializing the MoDE ACT policy. The old storing of single actions is removed.
- Gaussian action heads have an optional temporal 'bias' vector of learnable parameters that they can use to steer chunk-based initialization.
- MoDE-ACT class implementes the chunk-based initialization. All previous single action functionalities are removed and retained by the current code, simply by using `prediction_horizon=1`.
- The default setting for the synthetic data hydra experiment configs is now to use `learned_variance=False`, as learning the variance for a head predicting 60 chunks makes it easily collapse into a "winner-takes-all" situation (observed experimentally). With the default config, the MoDE-ACT policy successfully completes the multimodal tasks (see picture below).
<img width="840" height="886" alt="media_images_synthetic_rollout_trajectories_2876_6e4c67679f1363e56dbb" src="https://github.com/user-attachments/assets/dda0a9f7-34a8-4431-9840-e2d219c19438" />
