### PR TITLE
Fix non-contiguous ExecuTorch inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MoDE-ACT mixture heads initialize from aligned demonstrated action chunks with
   per-timestep component biases and horizon-tempered log-variance, preserving
   temporal structure and cross-action mode correspondence.
+- ExecuTorch deployment accepts non-contiguous camera batches produced by the
+  inference preprocessing pipeline.
 
 ### Added
 - The publish workflow verifies each release by installing it from PyPI in clean pip and uv environments and running a training smoke test.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MoDE-ACT mixture heads initialize from aligned demonstrated action chunks with
   per-timestep component biases and horizon-tempered log-variance, preserving
   temporal structure and cross-action mode correspondence.
+- ExecuTorch deployment accepts non-contiguous camera batches produced by the
+  inference preprocessing pipeline.
 
 ### Added
 - The publish workflow verifies each release by installing it from PyPI in clean pip and uv environments and running a training smoke test.

--- a/src/versatil/inference/policy_runtime/executorch_adapter.py
+++ b/src/versatil/inference/policy_runtime/executorch_adapter.py
@@ -23,7 +23,10 @@ class ExecuTorchModuleAdapter(nn.Module):
         observation_tensors: tuple[torch.Tensor, ...],
     ) -> tuple[torch.Tensor, ...]:
         """Run the ExecuTorch forward method."""
-        outputs = self._module.forward(observation_tensors)
+        contiguous_tensors = tuple(
+            tensor.contiguous() for tensor in observation_tensors
+        )
+        outputs = self._module.forward(contiguous_tensors)
         if isinstance(outputs, torch.Tensor):
             return (outputs,)
         return tuple(outputs)

--- a/tests/inference/policy_runtime/test_executorch_adapter.py
+++ b/tests/inference/policy_runtime/test_executorch_adapter.py
@@ -1,0 +1,43 @@
+"""Tests for versatil.inference.policy_runtime.executorch_adapter module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from versatil.inference.policy_runtime.executorch_adapter import (
+    ExecuTorchModuleAdapter,
+)
+
+EXECUTORCH_ADAPTER_MODULE = "versatil.inference.policy_runtime.executorch_adapter"
+
+
+@pytest.mark.unit
+def test_forward_makes_every_input_contiguous_before_executorch() -> None:
+    portable_library = MagicMock()
+    executorch_module = MagicMock()
+    output_tensor = torch.zeros(1)
+    executorch_module.forward.return_value = (output_tensor,)
+    portable_library._load_for_executorch.return_value = executorch_module
+    contiguous_tensor = torch.zeros(1, 4)
+    channel_last_frames = torch.zeros(1, 4, 4, 3).permute(0, 3, 1, 2)
+    non_contiguous_tensor = torch.stack([channel_last_frames])
+    if non_contiguous_tensor.is_contiguous():
+        raise RuntimeError("Test input must be non-contiguous.")
+
+    with patch(
+        f"{EXECUTORCH_ADAPTER_MODULE}.importlib.import_module",
+        return_value=portable_library,
+    ):
+        adapter = ExecuTorchModuleAdapter(model_path="policy.pte")
+        outputs = adapter(
+            observation_tensors=(non_contiguous_tensor, contiguous_tensor)
+        )
+
+    forwarded_tensors = executorch_module.forward.call_args.args[0]
+    assert all(tensor.is_contiguous() for tensor in forwarded_tensors)
+    torch.testing.assert_close(forwarded_tensors[0], non_contiguous_tensor)
+    assert forwarded_tensors[1] is contiguous_tensor
+    executorch_module.forward.assert_called_once()
+    assert len(outputs) == 1
+    torch.testing.assert_close(outputs[0], output_tensor)

--- a/tests/inference/policy_runtime/test_executorch_adapter.py
+++ b/tests/inference/policy_runtime/test_executorch_adapter.py
@@ -1,43 +1,73 @@
 """Tests for versatil.inference.policy_runtime.executorch_adapter module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+import torch.nn as nn
 
 from versatil.inference.policy_runtime.executorch_adapter import (
     ExecuTorchModuleAdapter,
+)
+from versatil.post_training_compression.constants import CompressionFilename
+from versatil.post_training_compression.deployment_backends.executorch_xnnpack import (
+    ExecutorchXNNPACKBackend,
 )
 
 EXECUTORCH_ADAPTER_MODULE = "versatil.inference.policy_runtime.executorch_adapter"
 
 
-@pytest.mark.unit
-def test_forward_makes_every_input_contiguous_before_executorch() -> None:
-    portable_library = MagicMock()
-    executorch_module = MagicMock()
-    output_tensor = torch.zeros(1)
-    executorch_module.forward.return_value = (output_tensor,)
-    portable_library._load_for_executorch.return_value = executorch_module
-    contiguous_tensor = torch.zeros(1, 4)
-    channel_last_frames = torch.zeros(1, 4, 4, 3).permute(0, 3, 1, 2)
-    non_contiguous_tensor = torch.stack([channel_last_frames])
-    if non_contiguous_tensor.is_contiguous():
-        raise RuntimeError("Test input must be non-contiguous.")
+class TestExecutorchModuleAdapter:
+    @pytest.mark.unit
+    def test_forward_makes_every_input_contiguous_before_executorch(self) -> None:
+        portable_library = MagicMock()
+        executorch_module = MagicMock()
+        output_tensor = torch.zeros(1)
+        executorch_module.forward.return_value = (output_tensor,)
+        portable_library._load_for_executorch.return_value = executorch_module
+        contiguous_tensor = torch.zeros(1, 4)
+        channel_last_frames = torch.zeros(1, 4, 4, 3).permute(0, 3, 1, 2)
+        non_contiguous_tensor = torch.stack([channel_last_frames])
+        if non_contiguous_tensor.is_contiguous():
+            raise RuntimeError("Test input must be non-contiguous.")
 
-    with patch(
-        f"{EXECUTORCH_ADAPTER_MODULE}.importlib.import_module",
-        return_value=portable_library,
-    ):
-        adapter = ExecuTorchModuleAdapter(model_path="policy.pte")
-        outputs = adapter(
-            observation_tensors=(non_contiguous_tensor, contiguous_tensor)
-        )
+        with patch(
+            f"{EXECUTORCH_ADAPTER_MODULE}.importlib.import_module",
+            return_value=portable_library,
+        ):
+            adapter = ExecuTorchModuleAdapter(model_path="policy.pte")
+            outputs = adapter(
+                observation_tensors=(non_contiguous_tensor, contiguous_tensor)
+            )
 
-    forwarded_tensors = executorch_module.forward.call_args.args[0]
-    assert all(tensor.is_contiguous() for tensor in forwarded_tensors)
-    torch.testing.assert_close(forwarded_tensors[0], non_contiguous_tensor)
-    assert forwarded_tensors[1] is contiguous_tensor
-    executorch_module.forward.assert_called_once()
-    assert len(outputs) == 1
-    torch.testing.assert_close(outputs[0], output_tensor)
+        forwarded_tensors = executorch_module.forward.call_args.args[0]
+        assert all(tensor.is_contiguous() for tensor in forwarded_tensors)
+        torch.testing.assert_close(forwarded_tensors[0], non_contiguous_tensor)
+        assert forwarded_tensors[1] is contiguous_tensor
+        executorch_module.forward.assert_called_once()
+        assert len(outputs) == 1
+        torch.testing.assert_close(outputs[0], output_tensor)
+
+    @pytest.mark.integration
+    @pytest.mark.requires_executorch
+    def test_runs_non_contiguous_camera_batch_through_pte(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        model = nn.ReLU().eval()
+        example_tensor = torch.zeros(2, 1, 3, 256, 256)
+        backend = ExecutorchXNNPACKBackend(max_batch_size=2)
+        artifact = backend.export(model=model, example_inputs=(example_tensor,))
+        model_path = tmp_path / CompressionFilename.EXECUTORCH_MODEL.value
+        model_path.write_bytes(artifact.model_bytes)
+        adapter = ExecuTorchModuleAdapter(model_path=str(model_path))
+        channel_last_frames = torch.ones(1, 256, 256, 3).permute(0, 3, 1, 2)
+        non_contiguous_tensor = torch.stack([channel_last_frames])
+        if non_contiguous_tensor.is_contiguous():
+            raise RuntimeError("Test input must be non-contiguous.")
+
+        outputs = adapter(observation_tensors=(non_contiguous_tensor,))
+
+        assert len(outputs) == 1
+        torch.testing.assert_close(outputs[0], non_contiguous_tensor)


### PR DESCRIPTION
## Summary

- normalize every ExecuTorch input tensor to contiguous layout at the runtime adapter boundary
- preserve values and avoid copies for inputs that are already contiguous
- add unit coverage for the adapter contract and a real ExecuTorch integration test that lowers, loads, and executes a `.pte`
- document the deployment fix in both changelogs

## Why

The LIBERO image preprocessing path produces camera batches with shape `(1, 1, 3, 256, 256)` and stride `(3, 3, 1, 768, 3)`. This layout is neither contiguous nor channels-last, so the ExecuTorch portable runtime rejects it before executing the model.

Applying `.contiguous()` at the adapter boundary fixes all observation inputs without requiring existing ARM `.pte` artifacts to be rebuilt.


